### PR TITLE
[mako] disable proximity sensor

### DIFF
--- a/device-lge-mako-configs/etc/mce/20no-proxim.conf
+++ b/device-lge-mako-configs/etc/mce/20no-proxim.conf
@@ -1,0 +1,2 @@
+/system/osso/dsm/proximity/ps_enabled=false
+


### PR DESCRIPTION
This will prevent spurious display blanks, until sensors work
