### PR TITLE
[helpers] add_new_device.sh is actually a bash script

### DIFF
--- a/helpers/add_new_device.sh
+++ b/helpers/add_new_device.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # droid-hal device add script
 # Copyright (c) 2014 Jolla Ltd.
 # Contact: Simonas Leleiva <simonas.leleiva@jollamobile.com>


### PR DESCRIPTION
When running this on a system that has /bin/sh as dash this script will fail as it contains bashisms.
