### PR TITLE
[all][systemd] Do not start droid-hal-init until all local filesystems a...

### DIFF
--- a/dsp/systemd/droid-hal-init.service
+++ b/dsp/systemd/droid-hal-init.service
@@ -5,6 +5,7 @@ After=local-fs.target systemd-udev-settle.service
 Before=basic.target network.target start-user-session@USER.service bluetooth.service ofono.service sensord.service
 DefaultDependencies=no
 Conflicts=shutdown.target actdead.target
+Requires=local-fs.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
...re mounted

Sometimes droid-hal-init starts before /system is mounted which results in properties not being read from /system
