### PR TITLE
[bluetooth] udev rules and system service for bluetooth initialization

### DIFF
--- a/device-lge-hammerhead-configs/lib/systemd/system/dev-ttyHS99.device
+++ b/device-lge-hammerhead-configs/lib/systemd/system/dev-ttyHS99.device
@@ -1,0 +1,4 @@
+[Unit]
+Description=HCI UART device
+Requires=hciattach.service
+Before=hciattach.service

--- a/device-lge-hammerhead-configs/lib/systemd/system/hciattach.service
+++ b/device-lge-hammerhead-configs/lib/systemd/system/hciattach.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run hciattach when HCI UART device becomes available
+Wants=bluetooth.service
+Before=bluetooth.service
+After=dev-ttyHS99.device
+ConditionPathExists=/data/property/persist.service.bdroid.bdaddr
+ConditionPathExists=/system/vendor/firmware
+
+[Service]
+Type=forking
+ExecStartPre=/usr/sbin/rfkill unblock bluetooth
+ExecStart=/usr/sbin/hciattach -f /system/vendor/firmware ttyHS99 bcm43xx 4000000 flow sleep /data/property/persist.service.bdroid.bdaddr

--- a/device-lge-hammerhead-configs/lib/udev/rules.d/999-bluetooth.rules
+++ b/device-lge-hammerhead-configs/lib/udev/rules.d/999-bluetooth.rules
@@ -1,0 +1,2 @@
+ACTION=="add", KERNEL=="ttyHS99", ENV{SYSTEMD_WANTS}=="dev-ttyHS99.device"
+KERNEL=="rfcomm*", MODE="0666", GROUP="bluetooth", OWNER="bluetooth"

--- a/droid-hal-hammerhead.spec
+++ b/droid-hal-hammerhead.spec
@@ -8,5 +8,8 @@
 %define vendor_pretty LG
 %define device_pretty Nexus 5
 
+Requires: rfkill
+Requires: bluez >= 4.101+git33
+
 %include rpm/droid-hal-device.inc
 


### PR DESCRIPTION
- Run hciattach when UART tty becomes available so that hci0 can be
  accessed
- Ensure /dev/rfcomm devices have proper permissions to enable sync
  over BT
