### PR TITLE
[all][init] Propagate NOTIFY_SOCKET down to droid-init-done.sh

### DIFF
--- a/dsp/bin/droid-hal-startup.sh
+++ b/dsp/bin/droid-hal-startup.sh
@@ -3,5 +3,10 @@ cd /
 sh /usr/libexec/droid/android-permission-fixup.sh &> /dev/null
 touch /dev/.coldboot_done
 export LD_LIBRARY_PATH=/usr/libexec/droid-hybris/system/lib/:/vendor/lib:/system/lib
+
+# Save systemd notify socket name to let droid-init-done.sh pick it up later
+mkdir -p /run/droid-hal
+echo $NOTIFY_SOCKET > /run/droid-hal/notify-socket-name
+
 exec /sbin/droid-hal-init
 

--- a/dsp/bin/droid-init-done.sh
+++ b/dsp/bin/droid-init-done.sh
@@ -36,7 +36,7 @@
 
 export LD_LIBRARY_PATH=/lib:/usr/lib
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
-export NOTIFY_SOCKET="@/org/freedesktop/systemd1/notify"
+export NOTIFY_SOCKET="$(cat /run/droid-hal/notify-socket-name)"
 DROID_PID=$(pgrep droid-hal-init)
 systemd-notify --pid=$DROID_PID --ready
 # Systemd has a bug and can't handle the situation that notifying daemon (this one)


### PR DESCRIPTION
NOTIFY_SOCKET has changed from @/org/freedesktop/systemd1/notify to
/run/systemd/notify between systemd 208 and 216, so a hard-coded value
breaks droid-hal-init with certain systemd version that wants
/run/systemd/notify.

The clean way is to propagate NOTIFY_SOCKET from droid-hal-startup.sh
down to droid-init-done.sh.
