### PR TITLE
[all][init] Create /run/droid-hal via tmpfiles

### DIFF
--- a/device-configs-all/usr/lib/tmpfiles.d/droid-hal.conf
+++ b/device-configs-all/usr/lib/tmpfiles.d/droid-hal.conf
@@ -1,0 +1,2 @@
+# Create empty directory to hold files for droid-hal
+D /run/droid-hal 0755 root root -

--- a/dsp/bin/droid-hal-startup.sh
+++ b/dsp/bin/droid-hal-startup.sh
@@ -5,7 +5,6 @@ touch /dev/.coldboot_done
 export LD_LIBRARY_PATH=/usr/libexec/droid-hybris/system/lib/:/vendor/lib:/system/lib
 
 # Save systemd notify socket name to let droid-init-done.sh pick it up later
-mkdir -p /run/droid-hal
 echo $NOTIFY_SOCKET > /run/droid-hal/notify-socket-name
 
 exec /sbin/droid-hal-init


### PR DESCRIPTION
We rather prefer using tmpfiles instead of manually creating the
directory with our good old friend mkdir.
