### PR TITLE
[all][init] Start droid-hal-init.service after loading systemd-tmpfiles-...

### DIFF
--- a/dsp/systemd/droid-hal-init.service
+++ b/dsp/systemd/droid-hal-init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=droid-hal-init
 Wants=systemd-udev-settle.service
-After=local-fs.target systemd-udev-settle.service
+After=local-fs.target systemd-udev-settle.service systemd-tmpfiles-setup.service
 Before=basic.target network.target bluetooth.service ofono.service sensord.service
 DefaultDependencies=no
 Conflicts=shutdown.target actdead.target


### PR DESCRIPTION
...setup.service

droid-hal-startup.sh passes socket information to droid-init-done.sh through /run/droid-hal/notify-socket-name file.
/run/droid-hal directory is setup by systemd-tmpfiles-setup.service. Running droid-hal-init.service before systemd-tmpfiles-setup.service will cause an error, so droid-hal-init.service should be started after systemd-tmpfiles-setup.service
