### PR TITLE
[mako] Enable Bluetooth HCI SMD during boot.

### DIFF
--- a/device-lge-mako-configs/lib/systemd/system/bluetooth.service.wants/hcismd.service
+++ b/device-lge-mako-configs/lib/systemd/system/bluetooth.service.wants/hcismd.service
@@ -1,0 +1,1 @@
+../hcismd.service

--- a/device-lge-mako-configs/lib/systemd/system/hcismd.service
+++ b/device-lge-mako-configs/lib/systemd/system/hcismd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Enable Bluetooth HCI over SMD
+DefaultDependencies=false
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/hcismd-enable.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=bluetooth.service

--- a/device-lge-mako-configs/sbin/hcismd-enable.sh
+++ b/device-lge-mako-configs/sbin/hcismd-enable.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Maximum number of attempts to enable hcismd to try to get
+# hci0 to come online.  Writing to sysfs too early seems to
+# not work, so we loop.
+MAXTRIES=15
+
+seq 1 $MAXTRIES | while read i ; do
+    echo 1 > /sys/module/hci_smd/parameters/hcismd_set
+    if [ -e /sys/class/bluetooth/hci0 ] ; then
+        # found hci0, exit successfully
+        exit 0
+    fi
+    sleep 1
+done
+# must have gotten through all our retries, fail
+exit 1


### PR DESCRIPTION
This needs CONFIG_BT_HCISMD=y in the kernel.  For some reason, writing to the sysfs files using tmpfiles.d at boot doesn't work - you need to wait some amount of time before writing to the file.