### PR TITLE
[hammerhead][wlan] Modularising will ensure correct MAC. Contributes to ...

### DIFF
--- a/device-lge-hammerhead-configs/usr/lib/modules-load.d/droid-hal-hammerhead.conf
+++ b/device-lge-hammerhead-configs/usr/lib/modules-load.d/droid-hal-hammerhead.conf
@@ -1,0 +1,2 @@
+# Modularise WLAN to delay its init after partition with its MAC is mounted.
+bcmdhd


### PR DESCRIPTION
...NEMO#731

Built-in module gets WLAN chip before persistent partition is mounted,
which contains its HW MAC address.

Hence we need to modularise WLAN