### PR TITLE
[dhd] Add missing buildrequire for git

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -77,6 +77,7 @@ Group:		System
 #BuildArch:	noarch
 # Note that oneshot is not in mer-core (yet)
 BuildRequires:  oneshot
+BuildRequires:  git
 BuildRequires:  systemd
 BuildRequires:  qt5-qttools-kmap2qmap >= 5.1.0+git5
 # These are only required if building on OBS


### PR DESCRIPTION
The repo calls may require use of git. Add missing BuildRequire for
git.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>