### PR TITLE
[tools] Add option for building device specific droid-hal-tools

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -10,6 +10,7 @@
 # device_target_cpu: Used for native builds. Normally the nested droid build env will do an old-fashioned cross-compile and produce non-x86 binaries (default armv7hl). This can be set to tell OBS what arch the binaries are. Eg Android for Intel arch must set this.
 # device_variant: for AOSP this is used as the TARGET_BUILD_VARIANT for lunch
 # makefstab_skip_entries: Allow entries into the makefstab unit creation to be skipped
+# enable_image_host_tools: If defined, builds device specific image creation host tools
 
 # Set defaults if not defined already:
 %if 0%{!?rpm_device:1}
@@ -144,6 +145,15 @@ Summary: Recovery image for droid-hal device: %{rpm_device}
 %description img-recovery
 The recovery.img for device
 
+################
+%if 0%{?enable_image_host_tools:1}
+%package host-tools
+Summary:    %{device} specific image creation tools for host environment
+
+%description host-tools
+%{summary}.
+%endif
+
 ################################################################
 # Begin prep/build section
 
@@ -266,6 +276,12 @@ mkdir -p $RPM_BUILD_ROOT/%{_bindir}/droid
 mkdir -p $RPM_BUILD_ROOT/img
 mkdir -p $RPM_BUILD_ROOT/boot
 mkdir -p $RPM_BUILD_ROOT/lib/modules
+
+%if 0%{?enable_image_host_tools:1}
+install -m 755 -D %{android_root}/out/host/linux-x86/bin/mkbootimg $RPM_BUILD_ROOT/%{_bindir}/mkbootimg-host
+install -m 755 -D %{android_root}/out/host/linux-x86/bin/img2simg $RPM_BUILD_ROOT/%{_bindir}/img2simg-host
+install -m 755 -D %{android_root}/out/host/linux-x86/bin/simg2img $RPM_BUILD_ROOT/%{_bindir}/simg2img-host
+%endif
 
 # Install
 %if 0%{?installable_zip:1}
@@ -489,3 +505,11 @@ fi
 %defattr(644,root,root,-)
 /boot/hybris-recovery.img
 
+%if 0%{?enable_image_host_tools:1}
+%files host-tools
+%defattr(-,root,root,-)
+%{_bindir}/mkbootimg-host
+%{_bindir}/img2simg-host
+%{_bindir}/simg2img-host
+
+%endif


### PR DESCRIPTION
Sometimes hardware vendors add custom features to the default android
image creation tools in their BSPs, or the BSP requires a specific
version of those tools. Added option "enable_device_specific_tools"
that can be set 1 in device specific spec file to build a custom
droid-hal-tools specific to that device BSP instead of using the default
droid-hal-tools.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>