### PR TITLE
Revert "[tools] Add option for device specific image creation tools"

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -101,6 +101,22 @@ Device specific droid headers for %{rpm_device}.
 Needed by libhybris
 
 ################
+%package tools
+Provides: droid-hal-tools
+Group:	Tools
+Summary: Some tools from android specific for %{device}
+License: ASL 2.0
+BuildRequires:  pkgconfig(zlib)
+
+Obsoletes: droid-hal-tools <= 0.0.2
+
+%description tools
+This package contains some tools that some hardware adaptations need for
+handling the android style content. This package is intended to be such
+that it can be installed on the device and is not meant to be used in host/sdk
+environment.
+
+################
 %package kernel
 Provides: droid-hal-kernel
 Group:	System
@@ -190,6 +206,19 @@ echo Verifying kernel config
 hybris/mer-kernel-check/mer_verify_kernel_config \
     %{android_root}/out/target/product/%{device}/obj/*/.config
 
+# Check if local overrides for tool mk files exist, otherwise dhd defaults are used
+if test -f rpm/helpers/mkbootimg.mk; then
+    export MKBOOTIMG_MK=$(pwd)/rpm/helpers/mkbootimg.mk
+fi
+
+if test -f rpm/helpers/simg2img.mk; then
+    export SIMG2IMG_MK=$(pwd)/rpm/helpers/simg2img.mk
+fi
+
+if test -f rpm/helpers/img2simg.mk; then
+    export IMG2SIMG_MK=$(pwd)/rpm/helpers/img2simg.mk
+fi
+
 echo Building local tools
 ANDROID_ROOT=$(readlink -e %{android_root})
 (cd %{dhd_path}/helpers; make ANDROID_ROOT=$ANDROID_ROOT)
@@ -266,6 +295,11 @@ mkdir -p $RPM_BUILD_ROOT/%{_bindir}/droid
 mkdir -p $RPM_BUILD_ROOT/img
 mkdir -p $RPM_BUILD_ROOT/boot
 mkdir -p $RPM_BUILD_ROOT/lib/modules
+
+# Install tools
+install -m 755 -D %{android_root}/system/core/mkbootimg/mkbootimg %{buildroot}/%{_bindir}/
+install -m 755 -D %{android_root}/system/core/libsparse/simg2img %{buildroot}/%{_bindir}/
+install -m 755 -D %{android_root}/system/core/libsparse/img2simg %{buildroot}/%{_bindir}/
 
 # Install
 %if 0%{?installable_zip:1}
@@ -467,6 +501,12 @@ fi
 %defattr(644,root,root,-)
 %{_libdir}/droid-devel/
 %{_libdir}/pkgconfig/*pc
+
+%files tools
+%defattr(-,root,root,-)
+%{_bindir}/mkbootimg
+%{_bindir}/img2simg
+%{_bindir}/simg2img
 
 %files kernel
 %defattr(644,root,root,-)

--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -10,7 +10,6 @@
 # device_target_cpu: Used for native builds. Normally the nested droid build env will do an old-fashioned cross-compile and produce non-x86 binaries (default armv7hl). This can be set to tell OBS what arch the binaries are. Eg Android for Intel arch must set this.
 # device_variant: for AOSP this is used as the TARGET_BUILD_VARIANT for lunch
 # makefstab_skip_entries: Allow entries into the makefstab unit creation to be skipped
-# enable_image_host_tools: If defined, builds device specific image creation host tools
 
 # Set defaults if not defined already:
 %if 0%{!?rpm_device:1}
@@ -145,15 +144,6 @@ Summary: Recovery image for droid-hal device: %{rpm_device}
 %description img-recovery
 The recovery.img for device
 
-################
-%if 0%{?enable_image_host_tools:1}
-%package host-tools
-Summary:    %{device} specific image creation tools for host environment
-
-%description host-tools
-%{summary}.
-%endif
-
 ################################################################
 # Begin prep/build section
 
@@ -276,12 +266,6 @@ mkdir -p $RPM_BUILD_ROOT/%{_bindir}/droid
 mkdir -p $RPM_BUILD_ROOT/img
 mkdir -p $RPM_BUILD_ROOT/boot
 mkdir -p $RPM_BUILD_ROOT/lib/modules
-
-%if 0%{?enable_image_host_tools:1}
-install -m 755 -D %{android_root}/out/host/linux-x86/bin/mkbootimg $RPM_BUILD_ROOT/%{_bindir}/mkbootimg-host
-install -m 755 -D %{android_root}/out/host/linux-x86/bin/img2simg $RPM_BUILD_ROOT/%{_bindir}/img2simg-host
-install -m 755 -D %{android_root}/out/host/linux-x86/bin/simg2img $RPM_BUILD_ROOT/%{_bindir}/simg2img-host
-%endif
 
 # Install
 %if 0%{?installable_zip:1}
@@ -505,11 +489,3 @@ fi
 %defattr(644,root,root,-)
 /boot/hybris-recovery.img
 
-%if 0%{?enable_image_host_tools:1}
-%files host-tools
-%defattr(-,root,root,-)
-%{_bindir}/mkbootimg-host
-%{_bindir}/img2simg-host
-%{_bindir}/simg2img-host
-
-%endif

--- a/helpers/img2simg.mk
+++ b/helpers/img2simg.mk
@@ -1,0 +1,23 @@
+# Makefile for img2simg
+
+SRCS+= backed_block.c
+SRCS+= output_file.c
+SRCS+= sparse.c
+SRCS+= sparse_crc32.c
+SRCS+= sparse_err.c
+SRCS+= sparse_read.c
+SRCS+= img2simg.c
+
+CPPFLAGS+= -Iinclude
+
+OBJS=$(SRCS:.c=.o)
+
+LIBS=-lz
+
+all: img2simg
+
+img2simg: $(OBJS)
+	$(CC) -o $@ $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LIBS)
+
+clean:
+	rm -rf $(OBJS) img2simg

--- a/helpers/makefile
+++ b/helpers/makefile
@@ -3,6 +3,9 @@ ANDROID_ROOT ?= ..
 
 # List of local tools we need to build
 TOOLS := apply-permissions usergroupgen
+MKBOOTIMG_MK ?= $(shell pwd)/mkbootimg.mk
+IMG2SIMG_MK ?= $(shell pwd)/img2simg.mk
+SIMG2IMG_MK ?= $(shell pwd)/simg2img.mk
 
 # Include directories
 CFLAGS += -I$(ANDROID_ROOT)/system/core/include/private/
@@ -10,9 +13,15 @@ CFLAGS += -I$(ANDROID_ROOT)/system/core/include/private/
 # C99 support
 CFLAGS += -std=c99
 
-all: $(TOOLS)
+all: $(TOOLS) image_tools
 
+image_tools:
+	make -f $(MKBOOTIMG_MK) -C $(ANDROID_ROOT)/system/core/mkbootimg/
+	make -f $(IMG2SIMG_MK) -C $(ANDROID_ROOT)/system/core/libsparse/
+	make -f $(SIMG2IMG_MK) -C $(ANDROID_ROOT)/system/core/libsparse/
 clean:
-	rm -f $(TOOLS)
+	rm -f $(TOOLS) $(ANDROID_ROOT)/system/core/mkbootimg/mkbootimg \
+	$(ANDROID_ROOT)/system/core/libsparse/img2simg \
+	$(ANDROID_ROOT)/system/core/libsparse/simg2img
 
 .PHONY: all clean

--- a/helpers/mkbootimg.mk
+++ b/helpers/mkbootimg.mk
@@ -1,0 +1,28 @@
+# Makefile for mkbootimg
+
+SRCS+= mkbootimg.c
+
+VPATH+= ../libmincrypt
+SRCS+= dsa_sig.c
+SRCS+= p256.c
+SRCS+= p256_ec.c
+SRCS+= p256_ecdsa.c
+SRCS+= rsa.c
+SRCS+= sha.c
+SRCS+= sha256.c
+
+CPPFLAGS+= -I.
+CPPFLAGS+= -I../include
+
+#LIBS+=
+
+OBJS=$(SRCS:.c=.o)
+
+all: mkbootimg
+
+mkbootimg: $(OBJS)
+	$(CC) -o $@ $(LDFLAGS) $(OBJS) $(LIBS)
+
+clean:
+	rm -rf $(OBJS) mkbootimg
+

--- a/helpers/simg2img.mk
+++ b/helpers/simg2img.mk
@@ -1,0 +1,23 @@
+# Makefile for simg2img
+
+SRCS+= backed_block.c
+SRCS+= output_file.c
+SRCS+= sparse.c
+SRCS+= sparse_crc32.c
+SRCS+= sparse_err.c
+SRCS+= sparse_read.c
+SRCS+= simg2img.c
+
+CPPFLAGS+= -Iinclude
+
+OBJS=$(SRCS:.c=.o)
+
+LIBS=-lz
+
+all: simg2img
+
+simg2img: $(OBJS)
+	$(CC) -o $@ $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LIBS)
+
+clean:
+	rm -rf $(OBJS) simg2img


### PR DESCRIPTION
This reverts commit f6bf842884bd5dfa458dd8b2b868337fc2c78d6f.

If device specific tools are needed, one should just modify a
device specific droid-hal-tools package for their adaptation.
It is much quicker and works better with legacy functionality.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>