### PR TITLE
[tools] Fix img2simg build. Fixes JB#28015

### DIFF
--- a/helpers/img2simg.mk
+++ b/helpers/img2simg.mk
@@ -8,6 +8,9 @@ SRCS+= sparse_err.c
 SRCS+= sparse_read.c
 SRCS+= img2simg.c
 
+# Too smart macros don't work with c99, filter it out.
+CFLAGS := $(filter-out -std=c99,$(CFLAGS))
+
 CPPFLAGS+= -Iinclude
 
 OBJS=$(SRCS:.c=.o)

--- a/helpers/simg2img.mk
+++ b/helpers/simg2img.mk
@@ -8,6 +8,9 @@ SRCS+= sparse_err.c
 SRCS+= sparse_read.c
 SRCS+= simg2img.c
 
+# Too smart macros don't work with c99, filter it out.
+CFLAGS := $(filter-out -std=c99,$(CFLAGS))
+
 CPPFLAGS+= -Iinclude
 
 OBJS=$(SRCS:.c=.o)


### PR DESCRIPTION
The output_file.c source uses too smart macro magics for it's own good,
which doesn't play well with C99. Disabled -std=c99 option for
img2simg to make it build without errors. Same added for simg2img
as it builds against same object files.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>