### PR TITLE
Allow having custom recovery image

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -19,6 +19,7 @@
 # device_variant: for AOSP this is used as the TARGET_BUILD_VARIANT for lunch
 # makefstab_skip_entries: Allow entries into the makefstab unit creation to be skipped
 # have_custom_img_boot: Defined when img-boot is packaged separately from droid-hal-device
+# have_custom_img_recovery: Defined when img-recovery is packaged separately from droid-hal-device
 
 # IMPORTANT if you want to comment out any macros in your .spec, delete the %
 # sign, otherwise they will remain defined! E.g.:
@@ -171,6 +172,7 @@ Requires(post): droid-config-%{rpm_device}
 The boot.img for device
 %endif
 
+%if 0%{!?have_custom_img_recovery:1}
 ################
 %package img-recovery
 Provides: droid-hal-img-recovery
@@ -180,6 +182,7 @@ Summary: Recovery image for droid-hal device: %{rpm_device}
 
 %description img-recovery
 The recovery.img for device
+%endif
 
 ################################################################
 # Begin prep/build section
@@ -425,8 +428,10 @@ mv $RPM_BUILD_ROOT/lib/modules/* $RPM_BUILD_ROOT/lib/modules/$KERNEL_RELEASE || 
 %if 0%{!?have_custom_img_boot:1}
 cp out/target/product/%{device}/hybris-boot.img $RPM_BUILD_ROOT/boot/
 %endif
-cp out/target/product/%{device}/hybris-recovery.img $RPM_BUILD_ROOT/boot/
 
+%if 0%{!?have_custom_img_recovery:1}
+cp out/target/product/%{device}/hybris-recovery.img $RPM_BUILD_ROOT/boot/
+%endif
 
 # Everything is installed; get a list of the units we installed to
 # allow the systemd_post to work... and then install that:
@@ -555,7 +560,8 @@ fi
 %endif
 %endif
 
+%if 0%{!?have_custom_img_recovery:1}
 %files img-recovery
 %defattr(644,root,root,-)
 /boot/hybris-recovery.img
-
+%endif


### PR DESCRIPTION
To be able to have post dhd build packaged recovery images, it
should be possible to disable recovery image generation from
droid-hal-device. Added option "have_custom_img_boot" for this.

[dhd] Allow having custom recovery image. Fixes NEMO#836

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>