### PR TITLE
[kernel] Add kernel EXTRAVERSION appending for OBS builds.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -216,6 +216,16 @@ cp %{SOURCE40} %{SOURCE0}
 echo _target_cpu is %{_target_cpu}
 
 %if 0%{?_obs_build_project:1}
+
+# Set up kernel extra version for OBS kernel builds
+if EXTRAVERSION_OLD=$(cat %android_root/kernel/Makefile | grep "EXTRAVERSION ="); then
+    sed -i "s/$EXTRAVERSION_OLD/EXTRAVERSION = +%{version}/g" %android_root/kernel/Makefile
+elif EXTRAVERSION_OLD=$(cat %android_root/linux/kernel/Makefile | grep "EXTRAVERSION ="); then
+    sed -i "s/$EXTRAVERSION_OLD/EXTRAVERSION = +%{version}/g" %android_root/linux/kernel/Makefile
+else
+    echo "Kernel Makefile not found, skipping EXTRAVERSION appending"
+fi
+
 # Hadk style build of android on OBS 
 echo Running droid build in HABUILD_SDK
 ubu-chroot -r /srv/mer/sdks/ubu "cd %android_root; %{?pre_actions}; source build/envsetup.sh; lunch %{device}%{?device_variant}; rm -f .repo/local_manifests/roomservice.xml; make %{?_smp_mflags} %{?hadk_make_target}%{!?hadk_make_target:hybris-hal}"


### PR DESCRIPTION
In order to get better trackability for kernel, append
+<dhd version> to kernel EXTRAVERSION when we do OBS based builds.

E.g. a previously "3.10.20" versioned kernel will turn into something
like "3.10.20+0.0.6-1".

The code checks also linux/kernel folder in case normal kernel/ folder
does not contain a Makefile. This is to be compatible with Intel android
trees.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>