### PR TITLE
[dhd] Add automatic detection of QCOM_BSP.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -381,6 +381,17 @@ cat <<EOF >> $HDRS/android-config.h.new
 /* Added by Droid HAL packaging for %{rpm_device} */
 %{?android_config}
 EOF
+# Detect QCOM_BSP and add the define into android-config.h if needed
+if (grep -q '^TARGET_USES_QCOM_BSP := true' %{android_root}/device/%{vendor}/*/BoardConfig*.mk || \
+    (grep -q 'PLATFORM_VERSION := 5.' %{android_root}/build/core/version_defaults.mk && \
+     grep -q '^BOARD_USES_QCOM_HARDWARE := true' %{android_root}/device/%{vendor}/*/BoardConfig*.mk)); then
+
+    echo Found QCOM_BSP
+    cat <<EOF >> $HDRS/android-config.h.new
+/* Added by automatic QCOM_BSP detection */
+#define QCOM_BSP 1
+EOF
+fi
 sed '0,/CONFIG GOES HERE/d' $HDRS/android-config.h >> $HDRS/android-config.h.new
 mv $HDRS/android-config.h.new $HDRS/android-config.h
 


### PR DESCRIPTION
Many Qualcomm devices (but not all) use QCOM_BSP which requires a definition in android-config.h for libhybris and qt5-qpa-hwcomposer-plugin to work. This has caused a lot of confusion and problems for new porters so let's try to automate the detection of QCOM_BSP by grepping the BoardConfig*.mk files in device tree.