### PR TITLE
[mako] modified patterns for cellular functionaliy and disabled the ui inversion

### DIFF
--- a/device-lge-mako-configs/var/lib/environment/compositor/droid-hal-device.conf
+++ b/device-lge-mako-configs/var/lib/environment/compositor/droid-hal-device.conf
@@ -8,5 +8,5 @@ QT_QPA_EGLFS_DEPTH=32
 QT_QPA_EGLFS_HIDECURSOR=1
 LIPSTICK_OPTIONS=-plugin evdevtouch:/dev/input/event2 -plugin evdevkeyboard:keymap=/usr/share/qt5/keymaps/droid.qmap
 
-QT_COMPOSITOR_NEGATE_INVERTED_Y=1
+QT_COMPOSITOR_NEGATE_INVERTED_Y=0
 # PRE_USER_SESSION_DISPLAY_OPTIONS=-displayX 187 -displayY -187 -displayRotation -9

--- a/patterns/mako/jolla-hw-adaptation-mako.yaml
+++ b/patterns/mako/jolla-hw-adaptation-mako.yaml
@@ -30,9 +30,21 @@ Requires:
 - qt5-qtdeclarative-import-positioning
 - qt5-qtdeclarative-import-sensors
 
+# since 1.1.9 api this is requiered for cellular functionality
+- jolla-sailfish-cellular-apps
+- telepathy-ring
+
+# For 1.1.7 only: provide settings layout for a device with valid GSM modem.
+# # Updates after 1.1.7 will autodetect the modem presence during runtime and change
+# # layout accordingly
+- jolla-settings-layout
+
 # This is a temporary acceptable hack to have mako orientation sensors 
 # See README for full description: https://github.com/mer-hybris/unblank-restart-sensors
 - unblank-restart-sensors
+
+# Needed for gps
+- geoclue-provider-hybris-community
 
 # This is needed for notification LEDs:
 - mce-plugin-libhybris


### PR DESCRIPTION
since mako inverted the ui the value must be changed to zero. added additional pattern entries for cellular packages and geoclue-provider-hybris-community

Change-Id: I35e463fef8440a16189e256053e782b78574970b