### PR TITLE
Remove kernel modules from droid-hal-device rpm

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -353,6 +353,8 @@ rm -f $RPM_BUILD_ROOT/sbin/modprobe
 sed -i -e '/^[[:space:]]*mount[[:space:]]/s/^/# Removed during droid-hal-device build : /' $RPM_BUILD_ROOT/*rc
 
 cp -a %{android_root}/out/target/product/%{device}/system/{bin,lib} $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/.
+# Remove kernel modules if installed under /system/lib/modules
+rm -rf $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib/modules
 cp -a %{android_root}/out/target/product/%{device}/obj/{lib,include} $RPM_BUILD_ROOT%{_libdir}/droid-devel/
 cp -a %{android_root}/out/target/product/%{device}/symbols $RPM_BUILD_ROOT%{_libdir}/droid-devel/
 


### PR DESCRIPTION
Remove kernel modules from droid-hal-device if those are installed under %{device}/system/modules. Modules are installed already on kernel modules package.