### PR TITLE
[dhd] Exclude provides and requires of all built libraries.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -39,7 +39,8 @@
 %define rpm_vendor %vendor
 %endif
 
-%define __provides_exclude_from ^%{_libexecdir}/droid-hybris/.*$
+%define __provides_exclude_from ^(%{_libexecdir}/droid-hybris/.*|%{_libdir}/droid-devel/.*)$
+%define __requires_exclude_from ^(%{_libexecdir}/droid-hybris/.*|%{_libdir}/droid-devel/.*)$
 %define android_root .
 %define dhd_path rpm/dhd
 


### PR DESCRIPTION
Current droid-hal-device always pulls in the -devel package during installation and when building dhd for e.g. Fairphone 2 the libraries built by hybris-hal require a lot of other libraries which causes significant amount of building of android libraries that are not built by default during hybris-hal build. Excluding all provides and requires of all built libraries in droid-devel and droid-hybris solves both problems and should not cause problems.