### PR TITLE
[build_packages] Add geoclue-providers-hybris.

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -78,6 +78,7 @@ buildmw qt5-feedback-haptics-droid-vibrator || die
 buildmw qt5-qpa-hwcomposer-plugin || die
 buildmw "https://github.com/mer-hybris/qtscenegraph-adaptation.git" rpm/qtscenegraph-adaptation-droid.spec || die
 buildmw "https://github.com/mer-packages/sensorfw.git" rpm/sensorfw-qt5-hybris.spec || die
+buildmw geoclue-providers-hybris || die
 read -p '"Build HA Middleware Packages built". Press Enter to continue.'
 popd
 


### PR DESCRIPTION
Needed for GPS to work in applications.