### PR TITLE
[build_packages] Fix build for non-armv7hl ports.

### DIFF
--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -34,7 +34,7 @@
 
 source ~/.hadk.env
 
-ARCH="${ARCH:-armv7hl}"
+ARCH="${PORT_ARCH:-armv7hl}"
 
 function minfo {
     echo -e "\e[01;34m* $* \e[00m"


### PR DESCRIPTION
Variable PORT_ARCH replaced ARCH in .hadk.env a long time ago and should also be fixed here.