### PR TITLE
[build_packages] sensorfw has moved to git.merproject.org.

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -77,7 +77,7 @@ buildmw "https://github.com/mer-hybris/pulseaudio-modules-droid.git" rpm/pulseau
 buildmw qt5-feedback-haptics-droid-vibrator || die
 buildmw qt5-qpa-hwcomposer-plugin || die
 buildmw "https://github.com/mer-hybris/qtscenegraph-adaptation.git" rpm/qtscenegraph-adaptation-droid.spec || die
-buildmw "https://github.com/mer-packages/sensorfw.git" rpm/sensorfw-qt5-hybris.spec || die
+buildmw "https://git.merproject.org/mer-core/sensorfw.git" rpm/sensorfw-qt5-hybris.spec || die
 buildmw geoclue-providers-hybris || die
 read -p '"Build HA Middleware Packages built". Press Enter to continue.'
 popd


### PR DESCRIPTION
Fix URL for sensorfw which has moved to https://git.merproject.org/mer-core/sensorfw.git.