### PR TITLE
[build_packages] Use qt-5.2 branch of qt5-qpa-hwcomposer-plugin until Qt 5.6 is available.

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -75,7 +75,7 @@ buildmw "https://github.com/nemomobile/mce-plugin-libhybris.git" || die
 buildmw ngfd-plugin-droid-vibrator || die
 buildmw "https://github.com/mer-hybris/pulseaudio-modules-droid.git" rpm/pulseaudio-modules-droid.spec || die
 buildmw qt5-feedback-haptics-droid-vibrator || die
-buildmw qt5-qpa-hwcomposer-plugin || die
+buildmwb qt5-qpa-hwcomposer-plugin qt-5.2 || die
 buildmw "https://github.com/mer-hybris/qtscenegraph-adaptation.git" rpm/qtscenegraph-adaptation-droid.spec || die
 buildmw "https://git.merproject.org/mer-core/sensorfw.git" rpm/sensorfw-qt5-hybris.spec || die
 buildmw geoclue-providers-hybris || die


### PR DESCRIPTION
Build fails otherwise.