### PR TITLE
 [dhd] allow People application to save contacts, let Phone application access contacts, call list

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -306,7 +306,7 @@ FSTAB_FILES="$(echo %{android_root}/out/target/product/%{device}/root/fstab.* %{
 shopt -u nullglob
 
 
-%{dhd_path}/helpers/makefstab --files $FSTAB_FILES  --skip auto /acct /boot /cache /data /misc /recovery /staging /storage/usbdisk /sys/fs/cgroup /sys/fs/cgroup/memory /sys/kernel/debug  /sys/kernel/config /dev/usb-ffs/adb %{?makefstab_skip_entries} --outputdir tmp/units
+%{dhd_path}/helpers/makefstab --files $FSTAB_FILES  --skip auto /acct /boot /cache /data /misc /recovery /staging /storage/usbdisk /sys/fs/cgroup /sys/fs/cgroup/memory /sys/kernel/debug  /sys/kernel/config /dev/usb-ffs/adb /tmp %{?makefstab_skip_entries} --outputdir tmp/units
 
 echo Fixing up mount points
 hybris/hybris-boot/fixup-mountpoints %{device} tmp/units/*
@@ -367,6 +367,8 @@ rm -f $RPM_BUILD_ROOT/sbin/modprobe
 
 # Now remove the mount commands from any .rc files as they're included in .mount unit files now
 sed -i -e '/^[[:space:]]*mount[[:space:]]/s/^/# Removed during droid-hal-device build : /' $RPM_BUILD_ROOT/*rc
+# remove the creation of /tmp to prevent wrong permissons 
+sed -i -e '/^[[:space:]]*mkdir[[:space:]]\/tmp[[:space:]]*/s/^/# Removed during droid-hal-device build : /' $RPM_BUILD_ROOT/*rc
 
 cp -a %{android_root}/out/target/product/%{device}/system/{bin,lib} $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/.
 # Remove kernel modules if installed under /system/lib/modules


### PR DESCRIPTION
This sed command from @mlehtima fixes the issue on Sonys scorpion, that /tmp has the wrong permissions. Which had effects in the peoples and phone applications.

[source of the sed command ](http://www.merproject.org/logs/%23sailfishos-porters/%23sailfishos-porters.2016-10-01.log.html#t2016-10-01T16:52:18)