### PR TITLE
[dhd] Skip mountpoint /dev/usb-ffs/adb because it breaks MTP.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -306,7 +306,7 @@ FSTAB_FILES="$(echo %{android_root}/out/target/product/%{device}/root/fstab.* %{
 shopt -u nullglob
 
 
-%{dhd_path}/helpers/makefstab --files $FSTAB_FILES  --skip auto /acct /boot /cache /data /misc /recovery /staging /storage/usbdisk /sys/fs/cgroup /sys/fs/cgroup/memory /sys/kernel/debug  /sys/kernel/config %{?makefstab_skip_entries} --outputdir tmp/units
+%{dhd_path}/helpers/makefstab --files $FSTAB_FILES  --skip auto /acct /boot /cache /data /misc /recovery /staging /storage/usbdisk /sys/fs/cgroup /sys/fs/cgroup/memory /sys/kernel/debug  /sys/kernel/config /dev/usb-ffs/adb %{?makefstab_skip_entries} --outputdir tmp/units
 
 echo Fixing up mount points
 hybris/hybris-boot/fixup-mountpoints %{device} tmp/units/*


### PR DESCRIPTION
Mounting functionfs to /dev/usb-ffs/adb as done by Android will break MTP in Sailfish OS so let's skip that mountpoint to make MTP work again. This problem appeared after https://github.com/mer-hybris/droid-hal-device/commit/dd9ce1e4ce9ff76726894341e0775a9e86b8e003 fixed the mountpoint name and the mount started to work. At least Fairphone 2 and OnePlus X were affected.