### PR TITLE
Usergen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 helpers/apply-permissions
-helpers/droid-user-add.sh
-helpers/droid-user-remove.sh
+helpers/droid.ids
 helpers/usergroupgen
 

--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -284,8 +284,7 @@ ANDROID_ROOT=$(readlink -e %{android_root})
 (cd %{dhd_path}/helpers; make ANDROID_ROOT=$ANDROID_ROOT)
 
 echo Building uid scripts
-%{dhd_path}/helpers/usergroupgen add > %{dhd_path}/helpers/droid-user-add.sh
-%{dhd_path}/helpers/usergroupgen remove > %{dhd_path}/helpers/droid-user-remove.sh
+%{dhd_path}/helpers/usergroupgen > %{dhd_path}/helpers/droid.ids
 
 echo Building udev rules
 mkdir tmp/udev.rules
@@ -429,13 +428,8 @@ ln -s /dev/null $RPM_BUILD_ROOT/etc/udev/rules.d/60-persistent-v4l.rules
 # Install init-debug which will provide usb access and non-blocking telnet
 cp -a %{android_root}/hybris/hybris-boot/init-script $RPM_BUILD_ROOT/init-debug
 
-# droid user support This may be better done by passing a list of
-# users/groups and running 'ensure_usergroups_exist newlist oldlist'
-# which would preserve oldlist in %%post and delete any users no longer
-# needed (unlikely!). This avoids the transient removal of uids and
-# group issues
-install -D %{dhd_path}/helpers/droid-user-add.sh $RPM_BUILD_ROOT%{_libdir}/droid/droid-user-add.sh
-install -D %{dhd_path}/helpers/droid-user-remove.sh $RPM_BUILD_ROOT%{_libdir}/droid/droid-user-remove.sh
+# droid user support
+install -D %{dhd_path}/helpers/droid.ids $RPM_BUILD_ROOT%{_libdir}/droid/droid.ids
 
 # Remove cruft
 rm -f $RPM_BUILD_ROOT/fstab.*
@@ -454,7 +448,7 @@ find $RPM_BUILD_ROOT/sbin/ -lname ../init -execdir echo rm {} \; -execdir echo "
 cp tmp/hw-release %{buildroot}/%{_libdir}/droid-devel/hw-release.vars
 
 # This ghost file must exist in the installroot
-touch $RPM_BUILD_ROOT/%{_libdir}/droid/droid-user-remove.sh.installed
+touch $RPM_BUILD_ROOT/%{_libdir}/droid/droid.ids.created
 
 # Kernel and module installation; to
 # /boot and modules to /lib as normal
@@ -507,7 +501,26 @@ done
 # Only run this during final cleanup
 if [ $1 -eq 0 ]; then
     echo purging old droid users and groups
-    %{_libdir}/droid/droid-user-remove.sh.installed || :
+    cat %{_libdir}/droid/droid.ids.created |while read name id; do
+        userdel -f $name
+        groupdel $name
+        sed -i "/^$name $id\$/d" droid.ids.created
+    done || :
+fi
+
+%pre
+#Compatibility with old droid-hal version - convert previous format
+#of droid-specific user/group information to current one.
+cd %{_libdir}/droid
+if [ $1 -gt 1 -a \
+     -e droid-user-remove.sh.installed -a \
+     -e droid-user-add.sh ]; then
+  #We've got the previous data in a shell-style generated text file. Convert.
+  #Only user/group name and ID is important, username=groupname, uid=gid.
+  sed -n -e 's/^groupadd -g \(.*\) \(.*\)/\2 \1/p' \
+      droid-user-add.sh > droid.ids.created || :
+  #Truncate the old file. rpm will remove it on its own.
+  echo '#!/bin/sh' > droid-user-remove.sh.installed
 fi
 
 %post
@@ -515,17 +528,29 @@ for u in $(cat %{_libdir}/droid/all-units.txt); do
 %systemd_post $u
 done
 cd %{_libdir}/droid
-# Upgrade: remove users using stored file, then add new ones
-if [ $1 -eq 2 ]; then
-    # Remove installed users (at this point droid-user-remove.sh
-    # refers to the new set of UIDs)
-    echo removing old droid users and groups
-    ./droid-user-remove.sh.installed || :
+# Upgrade: Check which users and groups were changed
+# between the previous version of droid-hal and current
+if [ $1 -gt 1 ]; then
+    ## Find users/groups that were removed by the current droid-hal ##
+    echo removing no longer used droid-hal users and groups
+    grep -v -F -x -f droid.ids droid.ids.created |while read name id; do
+        userdel -f $name
+        groupdel $name
+        sed -i "/^$name $id\$/d" droid.ids.created
+    done || :
 fi
-# Now for both install/update add the users and force-store a removal file
+# Now for both install/update add the users and mark which were added already
 echo creating droid users and groups
-./droid-user-add.sh || :
-cp -f droid-user-remove.sh droid-user-remove.sh.installed
+# On fresh installs, the file is not there at all and would break grep below
+if [ ! -e droid.ids.created ]; then
+    touch droid.ids.created
+fi
+
+grep -v -F -x -f droid.ids.created droid.ids |while read name id; do
+    groupadd -g $id $name || :
+    useradd -M -N -s /sbin/nologin -d / -u $id -g $id $name || :
+    echo $name $id >> droid.ids.created
+done
 
 # Now ensure default user has access to various subsystems this HA provides
 # These are the default android ones:
@@ -583,13 +608,12 @@ fi
 %defattr(-,root,root,-)
 /sbin/*
 # This binary should probably move to /sbin/
-%{_libdir}/droid/droid-user-add.sh
-%{_libdir}/droid/droid-user-remove.sh
+%{_libdir}/droid/droid.ids
 %{_libdir}/droid/all-units.txt
 # Created in %%post
 # init-debug
 %attr(755,root,root) /init-debug
-%ghost %attr(755, root, root) %{_libdir}/droid/droid-user-remove.sh.installed
+%ghost %attr(755, root, root) %{_libdir}/droid/droid.ids.created
 # droid binaries
 %{_libexecdir}/droid-hybris/system/bin/
 

--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -434,7 +434,7 @@ install -D %{dhd_path}/helpers/droid.ids $RPM_BUILD_ROOT%{_libdir}/droid/droid.i
 # Remove cruft
 rm -f $RPM_BUILD_ROOT/fstab.*
 rm -f $RPM_BUILD_ROOT/*goldfish*
-rm -rf $RPM_BUILD_ROOT/{proc,sys,dev,sepolicy} $RPM_BUILD_ROOT/{file,property,seapp}_contexts
+rm -rf $RPM_BUILD_ROOT/{proc,sys,dev,sepolicy,selinux_version} $RPM_BUILD_ROOT/{file,property,seapp,service}_contexts
 rm -rf $RPM_BUILD_ROOT/{charger,res,data}
 
 # Name this so droid-system-packager's droid-hal-startup.sh can find it

--- a/helpers/extract-headers.sh
+++ b/helpers/extract-headers.sh
@@ -192,6 +192,10 @@ extract_headers_to hardware_legacy \
     hardware/libhardware_legacy/include/hardware_legacy/vibrator.h \
     hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h
 
+check_header_exists system/media/camera/include/system/camera_vendor_tags.h && \
+    extract_headers_to system \
+        system/media/camera/include/system/camera_vendor_tags.h
+
 extract_headers_to cutils \
     system/core/include/cutils
 

--- a/helpers/usergroupgen.c
+++ b/helpers/usergroupgen.c
@@ -32,30 +32,18 @@
 
 int main(int argc, char *argv[])
 {
-    if (argc != 2 || (strcmp(argv[1], "remove") != 0 &&
-                      strcmp(argv[1], "add") != 0)) {
-        fprintf(stderr, "Usage: %s [add|remove]\n", argv[0]);
+    if (argc != 1 ) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
         return 1;
     }
 
-    int add = (strcmp(argv[1], "add") == 0);
-
-    printf("#!/bin/sh\n");
     for (int i = 0; i < android_id_count; i++) {
         if (android_ids[i].aid == 0) {
             /* Skip creating/removing the root user */
             continue;
-        } else if (add) {
-            /* Add groups before users */
-            printf("groupadd -g %i %s\n", android_ids[i].aid,
-                    android_ids[i].name);
-            printf("useradd -M -N -s /sbin/nologin -d / -u %i -g %i %s\n",
-                    android_ids[i].aid, android_ids[i].aid,
-                    android_ids[i].name);
         } else {
-            /* Remove groups after users */
-            printf("userdel -f %s\n", android_ids[i].name);
-            printf("groupdel %s\n", android_ids[i].name);
+            /* List user-group entries */
+            printf("%s %i\n", android_ids[i].name, android_ids[i].aid);
         }
     }
 


### PR DESCRIPTION
The logic is:

    Generate name-id pairs required by droid layer to droid.ids.
    On installation create all the required user and groups and note their
    names and ids to droid.ids.created.
    On update cross-check the two files and only add and remove the name-ids
    that have been changed.

ad. 1. usergroupgen.c no longer creates shellscript output, instead it creates
droid.ids which is a simple text file with name-space-id format, one per line.

ad. 2. postinstall script writes down every name-id it managed to create. It
does not write any user creation of which failed.

ad. 3. it is not verified during user/group removal if the user/group was
modified by the user or with a third-party script. If the entry disappeared
from droid-hal, we just remove it.

Special note: A conversion mechanism was added for upgrades from previous dhd
releases in the preinstall script. All users that were added in the previous
release are considered to have been created.