### PR TITLE
[helpers] Allow using specific version for droidmedia-localbuild

### DIFF
--- a/helpers/pack_source_droidmedia-localbuild.sh
+++ b/helpers/pack_source_droidmedia-localbuild.sh
@@ -3,7 +3,7 @@ if [ ! -f ./out/target/product/${DEVICE}/system/lib/libdroidmedia.so ]; then
     exit 1
 fi
 
-pkg=droidmedia-0.0.0
+pkg=droidmedia-"${1:-0.0.0}"
 fold=hybris/mw/$pkg
 rm -rf $fold
 mkdir $fold


### PR DESCRIPTION
This change allows to use external droidmedia version, but retains backward compatibility with defaulting to 0.0.0

For packaking local build of droidmedia, following commands from HADK needs to be revised to use version from droidmedia repository tag:

```
cd $ANDROID_ROOT
DROIDMEDIA_VERSION=$(git --git-dir external/droidmedia/.git describe --tags | sed -r "s/\-/\+/g")
rpm/dhd/helpers/pack_source_droidmedia-localbuild.sh $DROIDMEDIA_VERSION
mkdir -p hybris/mw/droidmedia-localbuild/rpm
cp rpm/dhd/helpers/droidmedia-localbuild.spec hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
sed -ie "s/0.0.0/$DROIDMEDIA_VERSION/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
mv hybris/mw/droidmedia-$DROIDMEDIA_VERSION.tgz hybris/mw/droidmedia-localbuild
rpm/dhd/helpers/build_packages.sh --build=hybris/mw/droidmedia-localbuild
```
