### PR TITLE
Use device-speceficed fixup-mountpoints file

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -309,7 +309,12 @@ shopt -u nullglob
 %{dhd_path}/helpers/makefstab --files $FSTAB_FILES  --skip auto /acct /boot /cache /data /misc /recovery /staging /storage/usbdisk /sys/fs/cgroup /sys/fs/cgroup/memory /sys/kernel/debug  /sys/kernel/config %{?makefstab_skip_entries} --outputdir tmp/units
 
 echo Fixing up mount points
+if [ -f rpm/fixup-mountpoints ];
+then
+rpm/fixup-mountpoints tmp/units/*
+else
 hybris/hybris-boot/fixup-mountpoints %{device} tmp/units/*
+fi
 
 echo Creating hw-release
 # based on http://www.freedesktop.org/software/systemd/man/os-release.html


### PR DESCRIPTION
Move fixup-mountpoints script to rpm directory. This allows ports been more independent of main hybris source tree