### PR TITLE
fix audioflingerglue-localbuild

### DIFF
--- a/helpers/audioflingerglue-localbuild.spec
+++ b/helpers/audioflingerglue-localbuild.spec
@@ -43,24 +43,34 @@ ls
 tar -xvf %name-%version.tgz
 %install
 
-mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/lib/
+if [ -f out/target/product/*/system/lib64/libaudioflingerglue.so ]; then
+DROIDLIB=lib64
+else
+DROIDLIB=lib
+fi
+
+mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 mkdir -p $RPM_BUILD_ROOT/%{_includedir}/audioflingerglue/
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/audioflingerglue/
 pushd %name-%version
-cp out/target/product/*/system/lib/libaudioflingerglue.so \
-    $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/lib/
+cp out/target/product/*/system/$DROIDLIB/libaudioflingerglue.so \
+    $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 
 cp out/target/product/*/system/bin/miniafservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
 cp external/audioflingerglue/*.h $RPM_BUILD_ROOT/%{_includedir}/audioflingerglue/
-cp external/audioflingerglue/hybris.c $RPM_BUILD_ROOT/%{_datadir}/audioflingerglue/
+sed -e "s/@TARGET_LIB_ARCH@/$DROIDLIB/" external/audioflingerglue/hybris.c.in > \
+    $RPM_BUILD_ROOT/%{_datadir}/audioflingerglue/hybris.c
 
 popd
-%files
+
+LIBAFSOLOC=$RPM_BUILD_ROOT/file.list
+echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libaudioflingerglue.so > %{LIBAFSOLOC}
+ 
+%files -f %{LIBAFSOLOC}
 %defattr(-,root,root,-)
-%{_libexecdir}/droid-hybris/system/lib/libaudioflingerglue.so
 %{_libexecdir}/droid-hybris/system/bin/miniafservice
 
 %files devel

--- a/helpers/pack_source_audioflingerglue-localbuild.sh
+++ b/helpers/pack_source_audioflingerglue-localbuild.sh
@@ -1,4 +1,8 @@
-if [ ! -f ./out/target/product/${DEVICE}/system/lib/libaudioflingerglue.so ]; then
+if [ -f ./out/target/product/${DEVICE}/system/lib/libaudioflingerglue.so ]; then 
+    DROIDLIB=lib
+elif [ -f ./out/target/product/${DEVICE}/system/lib64/libaudioflingerglue.so ]; then
+    DROIDLIB=lib64
+else
     echo "Please build audioflingerglue as per HADK instructions"
     exit 1
 fi
@@ -8,14 +12,14 @@ fold=hybris/mw/$pkg
 rm -rf $fold
 mkdir $fold
 
-mkdir -p $fold/out/target/product/${DEVICE}/system/lib
+mkdir -p $fold/out/target/product/${DEVICE}/system/${DROIDLIB}
 mkdir -p $fold/out/target/product/${DEVICE}/system/bin
 mkdir -p $fold/external/audioflingerglue
 
 cp ./external/audioflingerglue/*.h $fold/external/audioflingerglue/
-cp ./external/audioflingerglue/hybris.c $fold/external/audioflingerglue/
+cp ./external/audioflingerglue/hybris.c.in $fold/external/audioflingerglue/
 # Remove audioflingerglue bits from out/ (otherwise it would cause a conflict within droid-hal-$DEVICE):
-mv ./out/target/product/${DEVICE}/system/lib/libaudioflingerglue.so $fold/out/target/product/${DEVICE}/system/lib/
+mv ./out/target/product/${DEVICE}/system/${DROIDLIB}/libaudioflingerglue.so $fold/out/target/product/${DEVICE}/system/${DROIDLIB}/
 mv ./out/target/product/${DEVICE}/system/bin/miniafservice $fold/out/target/product/${DEVICE}/system/bin/
 
 tar -cjvf $fold.tgz -C $(dirname $fold) $pkg


### PR DESCRIPTION
update audioflingerglue-localbuild to match changes, fixing the lib path to allow for 64bit builds