### PR TITLE
Remove *.so.toc files from devel package.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -447,6 +447,7 @@ cp -a %{android_root}/out/target/product/%{device}/system/lib64 $RPM_BUILD_ROOT%
 # Remove kernel modules if installed under /system/lib/modules
 rm -rf $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib/modules
 cp -a %{android_root}/out/target/product/%{device}/obj/{lib,include} $RPM_BUILD_ROOT%{_libdir}/droid-devel/
+rm -rf $RPM_BUILD_ROOT%{_libdir}/droid-devel/lib/*.so.toc
 cp -a %{android_root}/out/target/product/%{device}/symbols $RPM_BUILD_ROOT%{_libdir}/droid-devel/
 
 HDRS=$RPM_BUILD_ROOT%{_libdir}/droid-devel/droid-headers


### PR DESCRIPTION
Since Android 7, build will create .toc files of all libraries. Toc is
txt file and include library symbol names. When devel package includes
those files OBS will result rpmlint error.