### PR TITLE
Add user to bluetooth group by default.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -649,6 +649,7 @@ cp -f droid-user-remove.sh droid-user-remove.sh.installed
 /usr/bin/groupadd-user camera || :
 /usr/bin/groupadd-user media || :
 /usr/bin/groupadd-user mtp || :
+/usr/bin/groupadd-user bluetooth || :
 
 ./generated-post-scripts.sh || :
 


### PR DESCRIPTION
Some bluetooth devices might use bluetooth user permission
and that is why user needs to be on that group.