### PR TITLE
[build_packages] Build native vibrator middleware by default.

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -138,8 +138,8 @@ if [ "$BUILDMW_REPO" == "" ]; then
 buildmw libhybris || die
 buildmw "https://github.com/mer-hybris/pulseaudio-modules-droid.git" rpm/pulseaudio-modules-droid.spec || die
 buildmw "https://github.com/nemomobile/mce-plugin-libhybris.git" || die
-buildmw ngfd-plugin-droid-vibrator || die
-buildmw qt5-feedback-haptics-droid-vibrator || die
+buildmw ngfd-plugin-droid-vibrator rpm/ngfd-plugin-native-vibrator.spec || die
+buildmw qt5-feedback-haptics-droid-vibrator rpm/qt5-feedback-haptics-native-vibrator.spec || die
 buildmw qt5-qpa-hwcomposer-plugin || die
 buildmw "https://git.merproject.org/mer-core/qtscenegraph-adaptation.git" rpm/qtscenegraph-adaptation-droid.spec || die
 buildmw "https://git.merproject.org/mer-core/sensorfw.git" rpm/sensorfw-qt5-hybris.spec || die


### PR DESCRIPTION
Required for https://github.com/mer-hybris/droid-hal-version/pull/10