### PR TITLE
[dhd] Build fix: Don't use std=c99 since we use g++ now.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -377,8 +377,6 @@ else
     echo "#include <private/android_filesystem_config.h>;" > generated_android_filesystem_config.h
 fi
 
-USE_STD_C99=1
-
 # files have changed in android >=8 so we need to supply different ones to the
 # makefile. we also need the cstring workaround thus handling both issues here
 # at once
@@ -389,15 +387,13 @@ if [ $ANDROID_VERSION_MAJOR -ge "8" ]; then
     echo "#include \"sparse_read.cpp\"" >> $ANDROID_ROOT/system/core/libsparse/sparse_read_fix.cpp
     IMG2SIMG_SOURCES="backed_block.c output_file.c sparse.c sparse_crc32.c sparse_err.c sparse_read_fix.cpp img2simg.c ../base/stringprintf.cpp"
     SIMG2IMG_SOURCES="backed_block.c output_file.c sparse.c sparse_crc32.c sparse_err.c sparse_read_fix.cpp simg2img.c ../base/stringprintf.cpp"
-
-    USE_STD_C99=0
 else
     IMG2SIMG_SOURCES="backed_block.c output_file.c sparse.c sparse_crc32.c sparse_err.c sparse_read.c img2simg.c"
     SIMG2IMG_SOURCES="backed_block.c output_file.c sparse.c sparse_crc32.c sparse_err.c sparse_read.c simg2img.c"
 fi
 
 pushd %{dhd_path}/helpers
-make USE_STD_C99=$USE_STD_C99 ANDROID_ROOT=$ANDROID_ROOT IMG2SIMG_SOURCES="$IMG2SIMG_SOURCES" SIMG2IMG_SOURCES="$SIMG2IMG_SOURCES"
+make ANDROID_ROOT=$ANDROID_ROOT IMG2SIMG_SOURCES="$IMG2SIMG_SOURCES" SIMG2IMG_SOURCES="$SIMG2IMG_SOURCES"
 popd
 
 echo Building uid scripts

--- a/helpers/makefile
+++ b/helpers/makefile
@@ -15,11 +15,6 @@ SIMG2IMG_MK ?= $(shell pwd)/simg2img.mk
 # Include directories
 CFLAGS += -I$(ANDROID_ROOT)/system/core/include/ -I$(ANDROID_ROOT)/
 
-ifeq ($(USE_STD_C99),1)
-# C99 support
-CFLAGS += -std=c99
-endif
-
 all: $(TOOLS) $(MKBOOTIMG) image_tools
 
 mkbootimg:


### PR DESCRIPTION
g++ is required for android 8 based builds at least. On older builds g++ breaks if std=c99 is used as well. Let's be consistent about the compiler and flags instead of switching around and causing issues.