### PR TITLE
[zypper] Allow unsigned package installation from local repos and files. JB#42244

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -130,7 +130,7 @@ sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install ssu domain sales
 sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install ssu dr sdk
 
 sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper ref -f
-sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper -n install droid-hal-$DEVICE-devel
+sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper -n install --allow-unsigned-rpm droid-hal-$DEVICE-devel
 
 pushd $ANDROID_ROOT/hybris/mw > /dev/null
 

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -250,7 +250,7 @@ function deploy {
         # and dup wouldn't work either
         # TODO: regexp match an RPM package filename to extract package name only,
         # so then it becomes possible to zypper install --force elegantly
-        sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper --non-interactive install --force $ANDROID_ROOT/droid-local-repo/$DEVICE/$PKG/*.rpm>>$LOG 2>&1|| die "can't install the package"
+        sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper --non-interactive install --force --allow-unsigned-rpm $ANDROID_ROOT/droid-local-repo/$DEVICE/$PKG/*.rpm>>$LOG 2>&1|| die "can't install the package"
     fi
     minfo "Building of $PKG finished successfully"
 }


### PR DESCRIPTION
New libzypp checks package signatures by default, and locally build packages are unsigned.