### PR TITLE
2 fixes for when building on xiaomi latte

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -414,7 +414,7 @@ mkdir tmp/units
 # skip various mounts which are not wanted (This is just in case they creep in)
 # First handle stupid spec quoting rules to get some args for makefstab
 shopt -s nullglob
-FSTAB_FILES="$(echo %{android_root}/out/target/product/%{device}/root/fstab.* %{android_root}/out/target/product/%{device}/root/*.rc %{android_root}/out/target/product/%{device}/vendor/etc/fstab.*)"
+FSTAB_FILES="$(echo %{android_root}/out/target/product/%{device}/root/fstab* %{android_root}/out/target/product/%{device}/root/*.rc %{android_root}/out/target/product/%{device}/vendor/etc/fstab*)"
 shopt -u nullglob
 
 

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -111,7 +111,7 @@ function buildconfigs() {
     rm -rf installroot
     mkdir installroot
     cd installroot
-    rpm2cpio $ANDROID_ROOT/droid-local-repo/$DEVICE/droid-configs/droid-config-$DEVICE-ssu-kickstarts-1-1.armv7hl.rpm | cpio -idv &> /dev/null
+    rpm2cpio $ANDROID_ROOT/droid-local-repo/$DEVICE/droid-configs/droid-config-$DEVICE-ssu-kickstarts-1-1.$PORT_ARCH.rpm | cpio -idv &> /dev/null
     cd ../../../
 
     hybris/droid-configs/droid-configs-device/helpers/process_patterns.sh >>$LOG 2>&1|| die "error while processing patterns"


### PR DESCRIPTION
DHD does not find any fstab files because the file does not have an extension, and  the arch is i486 so the kickstart file is not found.