### PR TITLE
Add build_bootimg helper script

### DIFF
--- a/helpers/build_bootimg_packages.sh
+++ b/helpers/build_bootimg_packages.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# build_bootimg_packages.sh - Build and/or install extra packages
+# needed for droid-hal-img-boot
+
+if [[ ! -d rpm/dhd ]]; then
+    echo $0: 'launch this script from the $ANDROID_ROOT directory'
+    exit 1
+fi
+# utilities
+. ./rpm/dhd/helpers/util.sh
+
+BUILDALL=y
+buildmw -u "https://github.com/sailfishos/yamui" || die
+buildmw -u "https://github.com/sailfishos/initrd-helpers/" || die
+buildmw -u "https://github.com/sailfishos/hw-ramdisk" || die
+BUILDALL=n


### PR DESCRIPTION
This helps with `droid-hal-img-boot` packages that need `yamui`, `e2fsprogs` and more, c.f. [hybris-initrd/droid-hal-device-img-boot.inc](https://github.com/mer-hybris/hybris-initrd/blob/ae58855e8bf911bbf6836e351da1677ec6f49129/droid-hal-device-img-boot.inc#L67-L74)

Didn't want to clutter `build_packages.sh` any further so it's split out into another script.

Dependent on #205 because it uses the named-arg `buildmw -u $URL -s $SPEC` syntax.