### PR TITLE
helpers: Try to use $HABUILD_DEVICE for droidmedia and audioflingerglue

### DIFF
--- a/helpers/pack_source_audioflingerglue-localbuild.sh
+++ b/helpers/pack_source_audioflingerglue-localbuild.sh
@@ -1,6 +1,8 @@
-if [ -f ./out/target/product/${DEVICE}/system/lib/libaudioflingerglue.so ]; then 
+OUT_DEVICE=${HABUILD_DEVICE:-$DEVICE}
+
+if [ -f ./out/target/product/${OUT_DEVICE}/system/lib/libaudioflingerglue.so ]; then
     DROIDLIB=lib
-elif [ -f ./out/target/product/${DEVICE}/system/lib64/libaudioflingerglue.so ]; then
+elif [ -f ./out/target/product/${OUT_DEVICE}/system/lib64/libaudioflingerglue.so ]; then
     DROIDLIB=lib64
 else
     echo "Please build audioflingerglue as per HADK instructions"
@@ -12,15 +14,15 @@ fold=hybris/mw/$pkg
 rm -rf $fold
 mkdir $fold
 
-mkdir -p $fold/out/target/product/${DEVICE}/system/${DROIDLIB}
-mkdir -p $fold/out/target/product/${DEVICE}/system/bin
+mkdir -p $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}
+mkdir -p $fold/out/target/product/${OUT_DEVICE}/system/bin
 mkdir -p $fold/external/audioflingerglue
 
 cp ./external/audioflingerglue/*.h $fold/external/audioflingerglue/
 cp ./external/audioflingerglue/hybris.c.in $fold/external/audioflingerglue/
-# Remove audioflingerglue bits from out/ (otherwise it would cause a conflict within droid-hal-$DEVICE):
-mv ./out/target/product/${DEVICE}/system/${DROIDLIB}/libaudioflingerglue.so $fold/out/target/product/${DEVICE}/system/${DROIDLIB}/
-mv ./out/target/product/${DEVICE}/system/bin/miniafservice $fold/out/target/product/${DEVICE}/system/bin/
+# Remove audioflingerglue bits from out/ (otherwise it would cause a conflict within droid-hal-$OUT_DEVICE):
+mv ./out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/libaudioflingerglue.so $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/
+mv ./out/target/product/${OUT_DEVICE}/system/bin/miniafservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
 
 tar -cjvf $fold.tgz -C $(dirname $fold) $pkg
 

--- a/helpers/pack_source_droidmedia-localbuild.sh
+++ b/helpers/pack_source_droidmedia-localbuild.sh
@@ -1,4 +1,6 @@
-if [ ! -f ./out/target/product/${DEVICE}/system/lib/libdroidmedia.so ]; then
+OUT_DEVICE=${HABUILD_DEVICE:-$DEVICE}
+
+if [ ! -f ./out/target/product/${OUT_DEVICE}/system/lib/libdroidmedia.so ]; then
     echo "Please build droidmedia as per HADK instructions"
     exit 1
 fi
@@ -8,17 +10,17 @@ fold=hybris/mw/$pkg
 rm -rf $fold
 mkdir $fold
 
-mkdir -p $fold/out/target/product/${DEVICE}/system/lib
-mkdir -p $fold/out/target/product/${DEVICE}/system/bin
+mkdir -p $fold/out/target/product/${OUT_DEVICE}/system/lib
+mkdir -p $fold/out/target/product/${OUT_DEVICE}/system/bin
 mkdir -p $fold/external/droidmedia
 
 cp ./external/droidmedia/*.h $fold/external/droidmedia/
 cp ./external/droidmedia/hybris.c $fold/external/droidmedia/
-# Remove droidmedia bits from out/ (otherwise it would cause a conflict within droid-hal-$DEVICE):
-mv ./out/target/product/${DEVICE}/system/lib/libdroidmedia.so $fold/out/target/product/${DEVICE}/system/lib/
-mv ./out/target/product/${DEVICE}/system/lib/libminisf.so $fold/out/target/product/${DEVICE}/system/lib/
-mv ./out/target/product/${DEVICE}/system/bin/minimediaservice $fold/out/target/product/${DEVICE}/system/bin/
-mv ./out/target/product/${DEVICE}/system/bin/minisfservice $fold/out/target/product/${DEVICE}/system/bin/
+# Remove droidmedia bits from out/ (otherwise it would cause a conflict within droid-hal-$OUT_DEVICE):
+mv ./out/target/product/${OUT_DEVICE}/system/lib/libdroidmedia.so $fold/out/target/product/${OUT_DEVICE}/system/lib/
+mv ./out/target/product/${OUT_DEVICE}/system/lib/libminisf.so $fold/out/target/product/${OUT_DEVICE}/system/lib/
+mv ./out/target/product/${OUT_DEVICE}/system/bin/minimediaservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
+mv ./out/target/product/${OUT_DEVICE}/system/bin/minisfservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
 
 tar -cjvf $fold.tgz -C $(dirname $fold) $pkg
 


### PR DESCRIPTION
If no `$HABUILD_DEVICE` is defined, fall back to `$DEVICE`.

Example:
`$HABUILD_DEVICE=kagura`
`$DEVICE=f8331`
Android's build system will create `$ANDROID_ROOT/out/target/product/kagura`

Any opinions on trying to use `$FAMILY` to detect whether to use `$HABUILD_DEVICE` like in https://github.com/mer-hybris/droid-hal-device/blob/31c62347e952ff7ac2da79c29020e92ed8a56008/helpers/build_packages.sh#L134-L138 ?