### PR TITLE
[helpers] Allow set $pkg ver in audiofingerglue tar. Fixes MER#2018

### DIFF
--- a/helpers/audioflingerglue-localbuild.spec
+++ b/helpers/audioflingerglue-localbuild.spec
@@ -9,7 +9,7 @@
 
 Name:          audioflingerglue
 Summary:       Android AudioFlinger glue library
-Version:       0.0.1
+Version:       0.0.0
 Release:       1
 Group:         System/Libraries
 License:       ASL 2.0

--- a/helpers/pack_source_audioflingerglue-localbuild.sh
+++ b/helpers/pack_source_audioflingerglue-localbuild.sh
@@ -7,7 +7,7 @@ else
     exit 1
 fi
 
-pkg=audioflingerglue-0.0.1
+pkg=audioflingerglue-"${1:-0.0.0}"
 fold=hybris/mw/$pkg
 rm -rf $fold
 mkdir $fold


### PR DESCRIPTION
Support setting the version of the audiofingerglue tar archive in dhd
like droidmedia.