### PR TITLE
[helpers] Add option to explicitly don't install a pkg

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -47,7 +47,7 @@ function usage() {
     exit 1
 }
 
-OPTIONS=$(getopt -o hdcm::vb:s: -l help,droid-hal,configs,mw::,version,build:,spec: -- "$@")
+OPTIONS=$(getopt -o hdcm::vb:s:D -l help,droid-hal,configs,mw::,version,build:,spec:,dont-install -- "$@")
 
 if [ $? -ne 0 ]; then
     echo "getopt error"
@@ -69,6 +69,7 @@ while true; do
       -h|--help) usage ;;
       -d|--droid-hal) BUILDDHD=1 ;;
       -c|--configs) BUILDCONFIGS=1 ;;
+      -D|--dont-install) DO_NOT_INSTALL=1;;
       -m|--mw) BUILDMW=1
           case "$2" in
               *) BUILDMW_REPO=$2;;

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -231,7 +231,7 @@ function buildmw() {
 
         build "$MW_BUILDSPEC"
 
-        deploy $PKG
+        deploy $PKG $DO_NOT_INSTALL
 
         popd > /dev/null
         popd > /dev/null
@@ -299,7 +299,7 @@ function buildpkg {
     initlog $PKG $(dirname `pwd`)
     shift
     build $@
-    deploy $PKG
+    deploy $PKG "$DO_NOT_INSTALL"
     popd > /dev/null
 }
 


### PR DESCRIPTION
Add an option to explicitly don't instal a pkg while deploying it.
This allows to build and deploy pkgs where not every sub-pkg is to
be installed. For example like updating ofono where there's a default
config, that conflicts with the device config or droid-vendor where
setcap fails.