### PR TITLE
dhd: Omit droidmedia+audioflingerglue from libexec

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -507,6 +507,15 @@ rm -rf $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib/modules
 cp -a %{android_root}/out/target/product/%{device}/obj/include $RPM_BUILD_ROOT%{_libdir}/droid-devel/
 rm -rf $RPM_BUILD_ROOT%{_libdir}/droid-devel/lib/*.so.toc
 
+# Omit audioflingerglue bits, they get packaged via audioflingerglue-localbuild
+rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/{lib,lib64}/libaudioflingerglue.so
+rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/bin/miniafservice
+# Omit droidmedia bits, they get packaged via droidmedia-localbuild
+rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/{lib,lib64}/libdroidmedia.so
+rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/{lib,lib64}/libminisf.so
+rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/bin/minimediaservice
+rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/bin/minisfservice
+
 HDRS=$RPM_BUILD_ROOT%{_libdir}/droid-devel/droid-headers
 mkdir -p $HDRS
 

--- a/helpers/pack_source_audioflingerglue-localbuild.sh
+++ b/helpers/pack_source_audioflingerglue-localbuild.sh
@@ -20,9 +20,8 @@ mkdir -p $fold/external/audioflingerglue
 
 cp ./external/audioflingerglue/*.h $fold/external/audioflingerglue/
 cp ./external/audioflingerglue/hybris.c.in $fold/external/audioflingerglue/
-# Remove audioflingerglue bits from out/ (otherwise it would cause a conflict within droid-hal-$OUT_DEVICE):
-mv ./out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/libaudioflingerglue.so $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/
-mv ./out/target/product/${OUT_DEVICE}/system/bin/miniafservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
+cp ./out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/libaudioflingerglue.so $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/
+cp ./out/target/product/${OUT_DEVICE}/system/bin/miniafservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
 
 tar -cjvf $fold.tgz -C $(dirname $fold) $pkg
 

--- a/helpers/pack_source_droidmedia-localbuild.sh
+++ b/helpers/pack_source_droidmedia-localbuild.sh
@@ -16,11 +16,10 @@ mkdir -p $fold/external/droidmedia
 
 cp ./external/droidmedia/*.h $fold/external/droidmedia/
 cp ./external/droidmedia/hybris.c $fold/external/droidmedia/
-# Remove droidmedia bits from out/ (otherwise it would cause a conflict within droid-hal-$OUT_DEVICE):
-mv ./out/target/product/${OUT_DEVICE}/system/lib/libdroidmedia.so $fold/out/target/product/${OUT_DEVICE}/system/lib/
-mv ./out/target/product/${OUT_DEVICE}/system/lib/libminisf.so $fold/out/target/product/${OUT_DEVICE}/system/lib/
-mv ./out/target/product/${OUT_DEVICE}/system/bin/minimediaservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
-mv ./out/target/product/${OUT_DEVICE}/system/bin/minisfservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
+cp ./out/target/product/${OUT_DEVICE}/system/lib/libdroidmedia.so $fold/out/target/product/${OUT_DEVICE}/system/lib/
+cp ./out/target/product/${OUT_DEVICE}/system/lib/libminisf.so $fold/out/target/product/${OUT_DEVICE}/system/lib/
+cp ./out/target/product/${OUT_DEVICE}/system/bin/minimediaservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
+cp ./out/target/product/${OUT_DEVICE}/system/bin/minisfservice $fold/out/target/product/${OUT_DEVICE}/system/bin/
 
 tar -cjvf $fold.tgz -C $(dirname $fold) $pkg
 


### PR DESCRIPTION
Remove `droidmedia` and `audioflingerglue` libs+bins from `$RPM_BUILD_ROOT/%{_libexecdir}` when building `droid-hal-device`, thus preventing clashing files with the `localbuild` variants.

This commit simply moves the logic around so that one can build all `HABUILD_SDK` tasks at once and then not have to worry about the order of execution for building `droid-hal` and `droidmedia/audioflingerglue-localbuild`.

Without this commit, one has to re-build the `droidmedia/audioflingerglue` libs in the `HABUILD_SDK` every time before packaging the `localbuild` variants.