### PR TITLE
Add gnu99 flag to build mkbootimg.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -373,6 +373,7 @@ if [ $ANDROID_VERSION_MAJOR -ge "8" ]; then
         > generated_android_filesystem_config.h
 else
     echo "#include <private/android_filesystem_config.h>;" > generated_android_filesystem_config.h
+    sed -i -e 's/CPPFLAGS+= -I..\/include/CPPFLAGS+= -I..\/include -std=gnu99/g' $MKBOOTIMG_MK
 fi
 
 # files have changed in android >=8 so we need to supply different ones to the


### PR DESCRIPTION
Lower than Android 8 version mkbootimg makefile needs gnu99 flag to build properly.