### PR TITLE
[dhd] Helpers cleanup

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -214,7 +214,7 @@ if [ "$BUILDPKG" == "1" ]; then
     if [ -z $BUILDPKG_PATH ]; then
        echo "--build requires an argument (path to package)"
     else
-        buildpkg $BUILDPKG_PATH ${BUILDSPEC_FILE[@]}
+        buildpkg $BUILDPKG_PATH "${BUILDSPEC_FILE[@]}"
     fi
 fi
 

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -33,7 +33,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-function usage() {
+usage() {
     echo "Usage: $0 [OPTION]..."
     echo "  -h, --help      you're reading it"
     echo "  -d, --droid-hal build droid-hal-device (rpm/)"

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -102,17 +102,17 @@ if [ $# -ne 0 ]; then
     exit 1
 fi
 
-if [[ ! -d rpm/dhd ]]; then
+if [ ! -d rpm/dhd ]; then
     echo $0: 'launch this script from the $ANDROID_ROOT directory'
     exit 1
 fi
 # utilities
 . ./rpm/dhd/helpers/util.sh
 
-if [ "$BUILDDHD" == "1" ]; then
+if [ "$BUILDDHD" = "1" ]; then
     builddhd
 fi
-if [ "$BUILDCONFIGS" == "1" ]; then
+if [ "$BUILDCONFIGS" = "1" ]; then
     if [ -n "$(grep '%define community_adaptation' $ANDROID_ROOT/hybris/droid-configs/rpm/droid-config-$DEVICE.spec)" ]; then
         sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -m sdk-install -R zypper se -i community-adaptation > /dev/null
         ret=$?
@@ -134,7 +134,7 @@ if [ "$BUILDCONFIGS" == "1" ]; then
     buildconfigs
 fi
 
-if [ "$BUILDMW" == "1" ]; then
+if [ "$BUILDMW" = "1" ]; then
     sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install ssu domain sales
     sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install ssu dr sdk
 
@@ -150,7 +150,7 @@ if [ "$BUILDMW" == "1" ]; then
 
     pushd $ANDROID_ROOT/hybris/mw > /dev/null
 
-    if [ "$BUILDMW_REPO" == "" ]; then
+    if [ "$BUILDMW_REPO" = "" ]; then
         buildmw -u "https://github.com/mer-hybris/libhybris" || die
 
         if [ $android_version_major -ge 8 ]; then
@@ -195,7 +195,7 @@ if [ "$BUILDMW" == "1" ]; then
             sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -m sdk-install -R zypper remove bluez-configs-mer
         fi
     else
-        if [[ -z "$BUILDSPEC_FILE" ]]; then
+        if [ -z "$BUILDSPEC_FILE" ]; then
             buildmw -u $BUILDMW_REPO || die
         else
             # Supply all given spec files from $BUILDSPEC_FILE array prefixed with "-s"
@@ -205,12 +205,12 @@ if [ "$BUILDMW" == "1" ]; then
     popd > /dev/null
 fi
 
-if [ "$BUILDVERSION" == "1" ]; then
+if [ "$BUILDVERSION" = "1" ]; then
     buildversion
     echo "----------------------DONE! Now proceed on creating the rootfs------------------"
 fi
 
-if [ "$BUILDPKG" == "1" ]; then
+if [ "$BUILDPKG" = "1" ]; then
     if [ -z $BUILDPKG_PATH ]; then
        echo "--build requires an argument (path to package)"
     else

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -34,19 +34,21 @@
 #
 
 usage() {
-    echo "Usage: $0 [OPTION]..."
-    echo "  -h, --help      you're reading it"
-    echo "  -d, --droid-hal build droid-hal-device (rpm/)"
-    echo "  -c, --configs   build droid-configs"
-    echo "  -m, --mw[=REPO] build HW middleware packages or REPO"
-    echo "  -v, --version   build droid-hal-version"
-    echo "  -b, --build=PKG build one package (PKG can include path)"
-    echo "  -s, --spec=SPEC optionally used with -m or -b"
-    echo "                  can be supplied multiple times to build multiple .spec files at once"
-    echo "  -D, --do-not-install"
-    echo "                  useful when package is needed only in the final image"
-    echo "                  especially when it conflicts in an SDK target"
-    echo " No options assumes building for all areas."
+    cat <<EOF
+Usage: $0 [OPTION]..."
+   -h, --help      you're reading it
+   -d, --droid-hal build droid-hal-device (rpm/)
+   -c, --configs   build droid-configs
+   -m, --mw[=REPO] build HW middleware packages or REPO
+   -v, --version   build droid-hal-version
+   -b, --build=PKG build one package (PKG can include path)
+   -s, --spec=SPEC optionally used with -m or -b
+                   can be supplied multiple times to build multiple .spec files at once
+   -D, --do-not-install
+                   useful when package is needed only in the final image
+                   especially when it conflicts in an SDK target
+ No options assumes building for all areas.
+EOF
     exit 1
 }
 

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -140,7 +140,7 @@ buildversion() {
 
 yesnoall() {
     if [ $BUILDALL == "y" ]; then
-        return `true`
+        return 0
     fi
     read -r -p "${1:-} [Y/n/all]" REPLY
     REPLY=${REPLY:-y}

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -139,7 +139,7 @@ buildversion() {
 }
 
 yesnoall() {
-    if [ $BUILDALL == "y" ]; then
+    if [ $BUILDALL = "y" ]; then
         return 0
     fi
     read -r -p "${1:-} [Y/n/all]" REPLY
@@ -222,7 +222,7 @@ buildmw() {
             git pull >>$LOG 2>&1|| die "pulling of updates failed"
         fi
 
-        if [ "$PKG" == "libhybris" ]; then
+        if [ "$PKG" = "libhybris" ]; then
             minfo "enabling debugging in libhybris..."
             sed "s/%{?qa_stage_devel:--enable-debug}/--enable-debug/g" -i rpm/libhybris.spec
             sed "s/%{?qa_stage_devel:--enable-trace}/--enable-trace/g" -i rpm/libhybris.spec
@@ -268,7 +268,7 @@ deploy() {
     sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -m sdk-install ssu ar local-$DEVICE-hal file://$LOCAL_REPO >>$LOG 2>&1|| die "can't add repo to target"
     sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -m sdk-install zypper ref || die "can't update pkg info"
     DO_NOT_INSTALL=$2
-    if [ "$PKG" == "libhybris" ]; then
+    if [ "$PKG" = "libhybris" ]; then
         # If this is the first installation of libhybris simply remove mesa,
         # otherwise proceed with force re-installation
         sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -m sdk-install -R zypper se -i mesa-llvmpipe > /dev/null

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -301,10 +301,10 @@ function buildpkg {
         die "Please specify path to the package"
     fi
     pushd $1 > /dev/null || die "Path not found: $1"
-    PKG=$(basename $1)
+    PKG=$(basename "$1")
     initlog $PKG $(dirname "$PWD")
     shift
-    build $@
+    build "$@"
     deploy $PKG "$DO_NOT_INSTALL"
     popd > /dev/null
 }

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -186,8 +186,8 @@ buildmw() {
 
 
     PKG="$(basename ${GIT_URL%.git})"
-    yesnoall "Build $PKG?"
-    if [ $? == "0" ]; then
+
+    if yesnoall "Build $PKG?" ; then
         # Remove this warning when ngfd-plugin-droid-vibrator will get rid of CMake
         if [ "$GIT_URL" = "ngfd-plugin-droid-vibrator" ]; then
             merror "WARNING: ngfd-plugin-droid-vibrator build is known to halt under various scenarios!"

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -93,7 +93,7 @@ sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper in -h | \
   fgrep -q -- --allow-unsigned-rpm && ALLOW_UNSIGNED_RPM="--allow-unsigned-rpm"
 
 function initlog {
-    LOGPATH=`pwd`
+    LOGPATH="$PWD"
     if [ -n "$2" ]; then
         LOGPATH=$2
     fi
@@ -104,7 +104,7 @@ function initlog {
 function buildconfigs() {
     PKG=droid-configs
     cd hybris/$PKG
-    initlog $PKG $(dirname `pwd`)
+    initlog $PKG $(dirname "$PWD")
     build rpm/droid-config-$DEVICE.spec
     deploy $PKG do_not_install
     # installroot no longer exists since Platform SDK 2.2.0, let's put KS back
@@ -132,7 +132,7 @@ function buildversion() {
     PKG=droid-hal-version-$DEVICE
     dir=$(dirname $(find hybris -name $PKG.spec))
     cd $dir/..
-    initlog $PKG $(dirname `pwd`)
+    initlog $PKG $(dirname "$PWD")
     build rpm/$PKG.spec
     deploy $PKG do_not_install
     cd ../../
@@ -302,7 +302,7 @@ function buildpkg {
     fi
     pushd $1 > /dev/null || die "Path not found: $1"
     PKG=$(basename $1)
-    initlog $PKG $(dirname `pwd`)
+    initlog $PKG $(dirname "$PWD")
     shift
     build $@
     deploy $PKG "$DO_NOT_INSTALL"

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -38,15 +38,15 @@ LOG="/dev/null"
 CREATEREPO="createrepo_c"
 ALLOW_UNSIGNED_RPM=""
 
-function minfo {
+minfo() {
     echo -e "\e[01;34m* $* \e[00m"
 }
 
-function merror {
+merror() {
     echo -e "\e[01;31m!! $* \e[00m"
 }
 
-function die {
+die() {
     if [[ "$LOG" != "/dev/null" && -f "$LOG" ]] ; then
         tail -n20 "$LOG"
         minfo "Check $LOG for full log."
@@ -92,7 +92,7 @@ mkdir -p $LOCAL_REPO
 sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper in -h | \
   fgrep -q -- --allow-unsigned-rpm && ALLOW_UNSIGNED_RPM="--allow-unsigned-rpm"
 
-function initlog {
+initlog() {
     LOGPATH="$PWD"
     if [ -n "$2" ]; then
         LOGPATH=$2
@@ -101,7 +101,7 @@ function initlog {
     [ -f "$LOG" ] && rm "$LOG"
 }
 
-function buildconfigs() {
+buildconfigs() {
     PKG=droid-configs
     cd hybris/$PKG
     initlog $PKG $(dirname "$PWD")
@@ -117,7 +117,7 @@ function buildconfigs() {
     hybris/droid-configs/droid-configs-device/helpers/process_patterns.sh >>$LOG 2>&1|| die "error while processing patterns"
 }
 
-function builddhd() {
+builddhd() {
     PKG=droid-hal-$DEVICE
     initlog $PKG
     if [ -e "rpm/droid-hal-$HABUILD_DEVICE.spec" ]; then
@@ -128,7 +128,7 @@ function builddhd() {
     deploy $PKG do_not_install
 }
 
-function buildversion() {
+buildversion() {
     PKG=droid-hal-version-$DEVICE
     dir=$(dirname $(find hybris -name $PKG.spec))
     cd $dir/..
@@ -138,7 +138,7 @@ function buildversion() {
     cd ../../
 }
 
-function yesnoall() {
+yesnoall() {
     if [ $BUILDALL == "y" ]; then
         return `true`
     fi
@@ -158,7 +158,7 @@ function yesnoall() {
     esac
 }
 
-function buildmw() {
+buildmw() {
     # Usage:
     #  -u     URL to use. Will check whether a folder with the same name as the
     #         git repo is already present in $ANDROID_ROOT/external/* and
@@ -238,7 +238,7 @@ function buildmw() {
     fi
 }
 
-function build {
+build() {
     SPECS=$@
     if [ -z "$SPECS" ]; then
         minfo "No spec file for package building specified, building all I can find."
@@ -254,7 +254,7 @@ function build {
     done
 }
 
-function deploy {
+deploy() {
     PKG=$1
     if [ -z "$PKG" ]; then
         die "Please provide a package name to build"
@@ -296,7 +296,7 @@ function deploy {
     minfo "Building of $PKG finished successfully"
 }
 
-function buildpkg {
+buildpkg() {
     if [ -z "$1" ]; then
         die "Please specify path to the package"
     fi


### PR DESCRIPTION
- Use builtin $PWD
- Fix quoting in case path names contain spaces [SC2046]
- Remove useless function keyword 
- Remove useless true just return zero
- Use if directly, using test is redundant
- Remove yesnoal, add --build-all
- Quote ${BUILDSPEC_FILE[@]} to avoid resplitting of elements
- Don't use bash == on posix test [] and use [] everywhere 
