### PR TITLE
dhd: Copy kernel modules from system/vendor/lib/modules. MER#2054

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -705,6 +705,7 @@ fi
 MOD_DIR=$RPM_BUILD_ROOT/lib/modules/$KERNEL_RELEASE
 mkdir -p $MOD_DIR
 cp -a out/target/product/%{device}/system/lib/modules/. $MOD_DIR/. || true
+cp -a out/target/product/%{device}/system/vendor/lib/modules/. $MOD_DIR/. || true
 cp -a out/target/product/%{device}/vendor/lib/modules/. $MOD_DIR/. || true
 cp -a out/target/product/%{device}/obj/*/modules.builtin $MOD_DIR/. || true
 cp -a out/target/product/%{device}/obj/*/modules.order $MOD_DIR/. || true


### PR DESCRIPTION
Some legacy devices use system/vendor/lib/modules as module location.