### PR TITLE
[dhd] Remove Source0 from droid_src_build. JB#46848

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -138,7 +138,6 @@ Version: 	0.0.6
 %if 0%{?_obs_build_project:1}
 Release: 	1
 %if 0%{?droid_src_build:1}
-Source0: %{name}-%{version}.tar.bz2
 BuildRequires: droid-bin-src-full
 %else
 # The repo sync service on OBS prepares a 'source tarball' of the rpm


### PR DESCRIPTION
Source0 have to be in main spec file, not in included
one. Without this OBS promotions does not work properly.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>