### PR TITLE
dhd: Add Source0 for droid_src_build.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -138,6 +138,7 @@ Version: 	0.0.6
 %if 0%{?_obs_build_project:1}
 Release: 	1
 %if 0%{?droid_src_build:1}
+Source0: droid-hal-%{rpm_device}-%{version}.tar.bz2
 BuildRequires: droid-bin-src-full
 %else
 # The repo sync service on OBS prepares a 'source tarball' of the rpm


### PR DESCRIPTION
[dhd] Add Source0 for droid_src_build. JB#46848

Source0 was moved to main spec file but version is not known in
that phase on promotion checks. Re-introduce it back after
version is known.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>