### PR TITLE
helpers: obsolete qt5-qpa-surfaceflinger-plugin

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -167,7 +167,6 @@ if [ "$BUILDMW" == "1" ]; then
         buildmw -u "https://github.com/mer-hybris/qt5-feedback-haptics-droid-vibrator" \
                 -s rpm/qt5-feedback-haptics-native-vibrator.spec || die
         buildmw -u "https://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin" || die
-        buildmw -u "https://github.com/mer-hybris/qt5-qpa-surfaceflinger-plugin" || die
         buildmw -u "https://git.merproject.org/mer-core/qtscenegraph-adaptation.git" \
                 -s rpm/qtscenegraph-adaptation-droid.spec || die
         if [ $android_version_major -ge 9 ]; then


### PR DESCRIPTION
No longer needed in adaptations, hwcomposer-plugin should be used instead.