### PR TITLE
helpers: Don't ask every time a package is build just ask if $BUILDMW=1 

### DIFF
--- a/helpers/build_bootimg_packages.sh
+++ b/helpers/build_bootimg_packages.sh
@@ -9,8 +9,6 @@ fi
 # utilities
 . ./rpm/dhd/helpers/util.sh
 
-BUILDALL=y
 buildmw -u "https://github.com/sailfishos/yamui" || die
 buildmw -u "https://github.com/sailfishos/initrd-helpers/" || die
 buildmw -u "https://github.com/sailfishos/hw-ramdisk" || die
-BUILDALL=n

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -135,6 +135,7 @@ if [ "$BUILDCONFIGS" = "1" ]; then
 fi
 
 if [ "$BUILDMW" = "1" ]; then
+
     sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install ssu domain sales
     sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install ssu dr sdk
 
@@ -151,6 +152,7 @@ if [ "$BUILDMW" = "1" ]; then
     pushd $ANDROID_ROOT/hybris/mw > /dev/null
 
     if [ "$BUILDMW_REPO" = "" ]; then
+        BUILDMW_ASK=y
         buildmw -u "https://github.com/mer-hybris/libhybris" || die
 
         if [ $android_version_major -ge 8 ]; then

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -33,7 +33,6 @@
 #
 
 PORT_ARCH="${PORT_ARCH:-armv7hl}"
-BUILDALL=n
 LOG="/dev/null"
 CREATEREPO="createrepo_c"
 ALLOW_UNSIGNED_RPM=""
@@ -138,8 +137,8 @@ buildversion() {
     cd ../../
 }
 
-yesnoall() {
-    if [ $BUILDALL = "y" ]; then
+buildmwquery() {
+    if [ ! "$BUILDMW_ASK" = "n" ]; then
         return 0
     fi
     read -r -p "${1:-} [Y/n/all]" REPLY
@@ -149,7 +148,7 @@ yesnoall() {
        true
        ;;
     [aA]*)
-       BUILDALL=y
+       BUILDMW_ASK=n
        true
        ;;
     *)
@@ -187,7 +186,7 @@ buildmw() {
 
     PKG="$(basename ${GIT_URL%.git})"
 
-    if yesnoall "Build $PKG?" ; then
+    if buildmwquery "Build $PKG?" ; then
         # Remove this warning when ngfd-plugin-droid-vibrator will get rid of CMake
         if [ "$GIT_URL" = "ngfd-plugin-droid-vibrator" ]; then
             merror "WARNING: ngfd-plugin-droid-vibrator build is known to halt under various scenarios!"


### PR DESCRIPTION
As explained by  @mlehtima:
>Also it might not be a good idea to completely remove the possibility
>to skip building certa in packages as often porters have to skip
>package because they have to build an older versi n of some package
>manually due to incompatibility with current Sailfish OS version.

Just ask for confirmation if the pkg should be build explicitly
when $BUILD_INDIVIDUAL_ASK is set or not n.