### PR TITLE
helpers: Don't use deprecated std c++0x

### DIFF
--- a/helpers/img2simg.mk
+++ b/helpers/img2simg.mk
@@ -2,7 +2,7 @@
 
 IMG2SIMG_SOURCES?= nosourcessupplied
 
-CXXFLAGS+= -std=c++0x
+CXXFLAGS+= -std=gnu++11
 
 CPPFLAGS+= -Iinclude
 CPPFLAGS+= -I../base/include

--- a/helpers/simg2img.mk
+++ b/helpers/simg2img.mk
@@ -2,7 +2,7 @@
 
 SIMG2IMG_SOURCES?= nosourcessupplied
 
-CXXFLAGS+= -std=c++0x
+CXXFLAGS+= -std=gnu++11
 
 CPPFLAGS+= -Iinclude
 CPPFLAGS+= -I../base/include


### PR DESCRIPTION
The standard flag c++0x is depreacted in gcc, use recommended c++11 or
gnu++11. This also fixes android 10 builds because libsparse is converted to
c++ typeof starting with android 10/platform-tools 29 and use c
typeof (which is a gnu extension).