### PR TITLE
Add a workaround for system mode PulseAudio.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -775,6 +775,25 @@ cp -f droid-user-remove.sh droid-user-remove.sh.installed
 /usr/bin/groupadd-user bluetooth || :
 /usr/bin/groupadd-user media_rw || :
 
+# FIXME: Workaround for droid-hal nuking audio group.
+# When audio group is removed and re-created pulse user is dropped from audio group.
+# To make sure that PulseAudio system mode is functional create all required users
+# and groups here as well. Remove this workaround when the group handling is a bit
+# more sane.
+getent group pulse-access >/dev/null || groupadd -r pulse-access
+getent group pulse >/dev/null || groupadd -f -g 171 -r pulse
+if ! getent passwd pulse >/dev/null ; then
+    if ! getent passwd 171 >/dev/null ; then
+        useradd -r -u 171 -g pulse -d %{_localstatedir}/run/pulse -s /sbin/nologin -c "PulseAudio System Daemon" pulse
+    else
+        useradd -r -g pulse -d %{_localstatedir}/run/pulse -s /sbin/nologin -c "PulseAudio System Daemon" pulse
+    fi
+fi
+usermod -G audio -a pulse || :
+usermod -G pulse -a pulse || :
+usermod -G pulse-access -a root || :
+# End workaround
+
 ./generated-post-scripts.sh || :
 
 # To add additional groups define a HA config, one can define those as part


### PR DESCRIPTION
When audio group is removed and re-created pulse user is dropped from audio group.
To make sure that PulseAudio system mode is functional create all required users
and groups here as well. Remove this workaround when the group handling is a bit
more sane.