### PR TITLE
helpers: Fix broken fs image building

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -352,7 +352,7 @@ if [ "$BUILDIMAGE" = "1" ]; then
     hybris/droid-configs/droid-configs-device/helpers/process_patterns.sh
     # Check if we need to build loop or fs image
     pattern_lookup=$(ls "$ANDROID_ROOT"/hybris/droid-configs/patterns/jolla-hw-adaptation-{$DEVICE,$HABUILD_DEVICE}.yaml 2>/dev/null)
-    if grep -q "^- droid-hal-{$DEVICE,$HABUILD_DEVICE}-kernel-modules" $pattern_lookup &>/dev/null; then
+    if grep -qE "^- droid-hal-($DEVICE|$HABUILD_DEVICE)-kernel-modules" $pattern_lookup &>/dev/null; then
         sudo mic create fs --arch=$PORT_ARCH \
             --tokenmap=ARCH:$PORT_ARCH,RELEASE:$RELEASE,EXTRA_NAME:"$EXTRA_NAME" \
             --record-pkgs=name,url \


### PR DESCRIPTION
This issue is a very recent issue introduced by PR #247, which added support for building loop images. The grep command however wasn't implemented properly and thus it doesn't detect `droid-hal-*-kernel-modules` in patterns like it should due to a syntactical issue.

This results in the assumption that a loop image shall be built and fails installing each package with `installing package X needs Y MB on the / filesystem` spammed on screen.

The exact same behavior has been seen by me and @nit-in already, but I'm pretty sure it would affect others too that do (local) mic builds after a dhd submodule update.

My solution simply fixes this mistake by using grep in extended regex mode while utilizing a logical or for the 2 different `DEVICE` values inside regular brackets.