### PR TITLE
dhd: Fix Android 6 <= based builds

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -533,13 +533,14 @@ if [ $ANDROID_VERSION_MAJOR -ge "7" ]; then
 mkdir -p $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/etc/init
 cp -a %{android_root}/out/target/product/%{device}/system/etc/init/servicemanager.rc $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/etc/init/
 echo "%{_libexecdir}/droid-hybris/system/etc/init/servicemanager.rc" > tmp/droid-hal.files
-else
-echo "" > tmp/droid-hal.files
-fi
 
 if [ -f %{android_root}/out/target/product/%{device}/system/etc/init/hybris_extras.rc ]; then
 cp -a %{android_root}/out/target/product/%{device}/system/etc/init/hybris_extras.rc $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/etc/init/
 echo "%{_libexecdir}/droid-hybris/system/etc/init/hybris_extras.rc" >> tmp/droid-hal.files
+fi
+
+else
+echo "" > tmp/droid-hal.files
 fi
 
 cp -a %{android_root}/out/target/product/%{device}/system/{bin,lib} $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/.


### PR DESCRIPTION
this problem happens if Android version is <= 6 and there is file
hybris_extras.rc in system/etc/init. It is introduced by commit
1fb8758dafa5 ("dhd: add support for one extra init rc, which can be
used to provide info from the adaptation to sfos")

In this case build_packages.sh fails with following error:

$ rpm/dhd/helpers/build_packages.sh

+ '[' 4 -ge 7 ']'
+ echo ''
+ '[' -f ./out/target/product/hammerhead/system/etc/init/hybris_extras.rc ']'
+ cp -a ./out/target/product/hammerhead/system/etc/init/hybris_extras.rc /media/data/port/android/installroot/usr/libexec/droid-hybris/system/etc/init/
cp: cannot create regular file `/media/data/port/android/installroot/usr/libexec/droid-hybris/system/etc/init/': No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.SrHvD1 (%install)