### PR TITLE
helpers: Fix hang build_packages.sh on missing patterns

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -289,7 +289,7 @@ if [ "$BUILDGG" = "1" ]; then
     # look for either DEVICE or HABUILD_DEVICE files, do not use wildcards as there could be other variants
     pattern_lookup=$(ls "$ANDROID_ROOT"/hybris/droid-configs/patterns/jolla-hw-adaptation-{$DEVICE,$HABUILD_DEVICE}.yaml 2>/dev/null)
 
-    if grep -q "^- gstreamer1.0-droid" $pattern_lookup &>/dev/null; then
+    if grep -q "^- gstreamer1.0-droid" "$pattern_lookup" &>/dev/null; then
         droidmedia_version=$(git --git-dir external/droidmedia/.git describe --tags 2>/dev/null | sed -r "s/\-/\+/g")
         if [ -z "$droidmedia_version" ]; then
             # in case of shallow clone:
@@ -310,9 +310,9 @@ if [ "$BUILDGG" = "1" ]; then
         minfo "Not building droidmedia and gstreamer1.0-droid due to the latter not being in patterns"
     fi
 
-    if grep -q "^- pulseaudio-modules-droid-hidl" $pattern_lookup &>/dev/null; then
+    if grep -q "^- pulseaudio-modules-droid-hidl" "$pattern_lookup" &>/dev/null; then
         minfo "Not building audioflingerglue and pulseaudio-modules-droid-glue due to pulseaudio-modules-droid-hidl in patterns"
-    elif grep -q "^- pulseaudio-modules-droid-glue" $pattern_lookup &>/dev/null; then
+    elif grep -q "^- pulseaudio-modules-droid-glue" "$pattern_lookup" &>/dev/null; then
         audioflingerglue_version=$(git --git-dir external/audioflingerglue/.git describe --tags 2>/dev/null | sed -r "s/\-/\+/g")
         if [ -z "$audioflingerglue_version" ]; then
             # in case of shallow clone:
@@ -359,7 +359,7 @@ if [ "$BUILDIMAGE" = "1" ]; then
     hybris/droid-configs/droid-configs-device/helpers/process_patterns.sh
     # Check if we need to build loop or fs image
     pattern_lookup=$(ls "$ANDROID_ROOT"/hybris/droid-configs/patterns/jolla-hw-adaptation-{$DEVICE,$HABUILD_DEVICE}.yaml 2>/dev/null)
-    if grep -qE "^- droid-hal-($DEVICE|$HABUILD_DEVICE)-kernel-modules" $pattern_lookup &>/dev/null; then
+    if grep -qE "^- droid-hal-($DEVICE|$HABUILD_DEVICE)-kernel-modules" "$pattern_lookup" &>/dev/null; then
         sudo mic create fs --arch=$PORT_ARCH \
             --tokenmap=ARCH:$PORT_ARCH,RELEASE:$RELEASE,EXTRA_NAME:"$EXTRA_NAME" \
             --record-pkgs=name,url \


### PR DESCRIPTION
if patterns have different name or just missing, then
build_packages.sh hangs.
pattern_lookup is empty and as a result grep execution does not receive file as
a parameter and infinitely waits for input from stdin.