### PR TITLE
helpers: Look for droidmedia and audioflingerglue builds only for current device.

### DIFF
--- a/helpers/audioflingerglue-localbuild.spec
+++ b/helpers/audioflingerglue-localbuild.spec
@@ -44,7 +44,7 @@ ls
 tar -xvf %name-%version.tgz
 %install
 
-if [ -f out/target/product/*/system/lib64/libaudioflingerglue.so ]; then
+if [ -f out/target/product/@DEVICE@/system/lib64/libaudioflingerglue.so ]; then
 DROIDLIB=lib64
 else
 DROIDLIB=lib
@@ -55,10 +55,10 @@ mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 mkdir -p $RPM_BUILD_ROOT/%{_includedir}/audioflingerglue/
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/audioflingerglue/
 pushd %name-%version
-cp out/target/product/*/system/$DROIDLIB/libaudioflingerglue.so \
+cp out/target/product/@DEVICE@/system/$DROIDLIB/libaudioflingerglue.so \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 
-cp out/target/product/*/system/bin/miniafservice \
+cp out/target/product/@DEVICE@/system/bin/miniafservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
 cp external/audioflingerglue/*.h $RPM_BUILD_ROOT/%{_includedir}/audioflingerglue/

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -315,6 +315,7 @@ if [ "$BUILDGG" = "1" ]; then
         cp rpm/dhd/helpers/droidmedia-localbuild.spec hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         sed -ie "s/0.0.0/$droidmedia_version/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         sed -ie "s/@PORT_ARCH@/$PORT_ARCH/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
+        sed -ie "s/@DEVICE@/$HABUILD_DEVICE/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         mv hybris/mw/droidmedia-"$droidmedia_version".tgz hybris/mw/droidmedia-localbuild
         buildmw -u "droidmedia-localbuild" || die
         buildmw -u "https://github.com/sailfishos/gst-droid.git" || die
@@ -338,6 +339,7 @@ if [ "$BUILDGG" = "1" ]; then
         fi
         cp rpm/dhd/helpers/audioflingerglue-localbuild.spec hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         sed -ie "s/0.0.0/$audioflingerglue_version/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
+        sed -ie "s/@DEVICE@/$HABUILD_DEVICE/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         mv hybris/mw/audioflingerglue-"$audioflingerglue_version".tgz hybris/mw/audioflingerglue-localbuild
         buildmw -u "audioflingerglue-localbuild" || die
         buildmw -u "https://github.com/mer-hybris/pulseaudio-modules-droid-glue.git" || die

--- a/helpers/droidmedia-localbuild.spec
+++ b/helpers/droidmedia-localbuild.spec
@@ -54,7 +54,7 @@ tar -xvf %name-%version.tgz
 %install
 
 pushd %name-%version
-if [ -f out/target/product/*/system/lib64/libdroidmedia.so ]; then
+if [ -f out/target/product/@DEVICE@/system/lib64/libdroidmedia.so ]; then
 DROIDLIB=lib64
 else
 DROIDLIB=lib
@@ -64,16 +64,16 @@ mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 mkdir -p $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/droidmedia/
-cp out/target/product/*/system/$DROIDLIB/libdroidmedia.so \
+cp out/target/product/@DEVICE@/system/$DROIDLIB/libdroidmedia.so \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 
-cp out/target/product/*/system/$DROIDLIB/libminisf.so \
+cp out/target/product/@DEVICE@/system/$DROIDLIB/libminisf.so \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 
-cp out/target/product/*/system/bin/minimediaservice \
+cp out/target/product/@DEVICE@/system/bin/minimediaservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
-cp out/target/product/*/system/bin/minisfservice \
+cp out/target/product/@DEVICE@/system/bin/minisfservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
 cp external/droidmedia/*.h $RPM_BUILD_ROOT/%{_includedir}/droidmedia/


### PR DESCRIPTION
[helpers] Look for droidmedia and audioflingerglue builds only for current device.

This helps when doing local builds for more than one device using the same Android source tree.