### PR TITLE
helpers: Remove not needed vibrator packages from build_packages.sh

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -263,10 +263,6 @@ if [ "$BUILDMW" = "1" ]; then
         buildmw -u "https://github.com/mer-hybris/audiosystem-passthrough.git" || die
         buildmw -u "https://github.com/mer-hybris/pulseaudio-modules-droid-hidl.git" || die
         buildmw -u "https://github.com/nemomobile/mce-plugin-libhybris.git" || die
-        buildmw -u "https://github.com/mer-hybris/ngfd-plugin-droid-vibrator" \
-                -s rpm/ngfd-plugin-native-vibrator.spec || die
-        buildmw -u "https://github.com/mer-hybris/qt5-feedback-haptics-droid-vibrator" \
-                -s rpm/qt5-feedback-haptics-native-vibrator.spec || die
         buildmw -u "https://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin" || die
         buildmw -u "https://git.sailfishos.org/mer-core/qtscenegraph-adaptation.git" \
                 -s rpm/qtscenegraph-adaptation-droid.spec || die


### PR DESCRIPTION
[helpers] Remove not needed vibrator packages from build_packages.sh

These packages have been available in Jolla repos for a long time, no need to build them here.