### PR TITLE
Improve package version handling

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -49,6 +49,8 @@ Usage: $0 [OPTION]..."
    -D, --do-not-install
                    useful when package is needed only in the final image
                    especially when it conflicts in an SDK target
+   -N  --no-auto-version
+                   Tell mb2 to not fix the version inside a spec file
    -o, --offline   build offline after all repos have been cloned or refreshed
    -n, --no-delete do not delete existing packages when adding to repo
 
@@ -57,7 +59,7 @@ EOF
     exit 1
 }
 
-OPTIONS=$(getopt -o hdcm::gvib:s:Don -l help,droid-hal,configs,mw::,gg,version,mic,build:,spec:,do-not-install,offline,no-delete -- "$@")
+OPTIONS=$(getopt -o hdcm::gvib:s:DonN -l help,droid-hal,configs,mw::,gg,version,mic,build:,spec:,do-not-install,offline,no-delete,no-auto-version -- "$@")
 
 if [ $? -ne 0 ]; then
     echo "getopt error"
@@ -83,6 +85,7 @@ while true; do
       -d|--droid-hal) BUILDDHD=1 ;;
       -c|--configs) BUILDCONFIGS=1 ;;
       -D|--do-not-install) DO_NOT_INSTALL=1;;
+      -N|--no-auto-version) NO_AUTO_VERSION=--no-fix-version ;;
       -m|--mw) BUILDMW=1
           BUILDMW_ASK=1
           case "$2" in

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -314,16 +314,12 @@ if [ "$BUILDGG" = "1" ]; then
         fi
         rpm/dhd/helpers/pack_source_droidmedia-localbuild.sh "$droidmedia_version"
         mkdir -p hybris/mw/droidmedia-localbuild/rpm
-        if [ -d .git ] && [ ! -d hybris/mw/droidmedia-localbuild/.git ]; then
-            # for the top-level .git adaptations such as Xperia 10 Android 9, otherwise mb2 will complain:
-            (cd hybris/mw/droidmedia-localbuild; git init; git commit --allow-empty -m "initial")
-        fi
         cp rpm/dhd/helpers/droidmedia-localbuild.spec hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         sed -ie "s/0.0.0/$droidmedia_version/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         sed -ie "s/@PORT_ARCH@/$PORT_ARCH/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         sed -ie "s/@DEVICE@/$HABUILD_DEVICE/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         mv hybris/mw/droidmedia-"$droidmedia_version".tgz hybris/mw/droidmedia-localbuild
-        buildmw -u "droidmedia-localbuild" || die
+        buildmw -Nu "droidmedia-localbuild" || die
         if grep -qs "^- gstreamer1.0-droid" "$pattern_lookup" ||
            grep -qs "^Requires: gstreamer1.0-droid" "$metapackage_lookup"; then
             buildmw -u "https://github.com/sailfishos/gst-droid.git" || die
@@ -352,15 +348,11 @@ if [ "$BUILDGG" = "1" ]; then
         fi
         rpm/dhd/helpers/pack_source_audioflingerglue-localbuild.sh "$audioflingerglue_version"
         mkdir -p hybris/mw/audioflingerglue-localbuild/rpm
-        if [ -d .git ] && [ ! -d hybris/mw/audioflingerglue-localbuild/.git ]; then
-            # for the top-level .git adaptations such as Xperia 10 Android 9, otherwise mb2 will complain:
-            (cd hybris/mw/audioflingerglue-localbuild; git init; git commit --allow-empty -m "initial")
-        fi
         cp rpm/dhd/helpers/audioflingerglue-localbuild.spec hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         sed -ie "s/0.0.0/$audioflingerglue_version/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         sed -ie "s/@DEVICE@/$HABUILD_DEVICE/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         mv hybris/mw/audioflingerglue-"$audioflingerglue_version".tgz hybris/mw/audioflingerglue-localbuild
-        buildmw -u "audioflingerglue-localbuild" || die
+        buildmw -Nu "audioflingerglue-localbuild" || die
         buildmw -u "https://github.com/mer-hybris/pulseaudio-modules-droid-glue.git" || die
     else
         minfo "Not building audioflingerglue and pulseaudio-modules-droid-glue due to the latter not being in patterns"

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -307,11 +307,14 @@ if [ "$BUILDGG" = "1" ]; then
        grep -qs "^Requires: gstreamer1.0-droid" "$metapackage_lookup" ||
        grep -qs "^- gmp-droid" "$pattern_lookup" ||
        grep -qs "^Requires: gmp-droid" "$metapackage_lookup"; then
-        droidmedia_version=$(git --git-dir external/droidmedia/.git describe --tags 2>/dev/null | sed -r "s/\-/\+/g")
+        pkg=droidmedia
+        cd external/$pkg || die "Could not change directory to external/$pkg"
+        droidmedia_version=$(get_package_version "$pkg")
         if [ -z "$droidmedia_version" ]; then
-            # in case of shallow clone:
-            droidmedia_version=999.99999999.99
+            # Could not obtain version, function call will have shown the error
+            exit 1
         fi
+        cd ../..
         rpm/dhd/helpers/pack_source_droidmedia-localbuild.sh "$droidmedia_version" ||
             die "Failed to pack_source_droidmedia-localbuild.sh"
         mkdir -p hybris/mw/droidmedia-localbuild/rpm
@@ -342,10 +345,12 @@ if [ "$BUILDGG" = "1" ]; then
         minfo "Not building audioflingerglue and pulseaudio-modules-droid-glue due to pulseaudio-modules-droid-hidl in patterns"
     elif grep -qs "- pulseaudio-modules-droid-glue" "$pattern_lookup" ||
          grep -qs "Requires: pulseaudio-modules-droid-glue" "$metapackage_lookup"; then
-        audioflingerglue_version=$(git --git-dir external/audioflingerglue/.git describe --tags 2>/dev/null | sed -r "s/\-/\+/g")
+        pkg=audioflingerglue
+        cd external/$pkg || die "Could not change directory to external/$pkg"
+        audioflingerglue_version=$(get_package_version "$pkg")
         if [ -z "$audioflingerglue_version" ]; then
-            # in case of shallow clone:
-            audioflingerglue_version=999.0.0
+            # Could not obtain version, function call will have shown the error
+            exit 1
         fi
         rpm/dhd/helpers/pack_source_audioflingerglue-localbuild.sh "$audioflingerglue_version" ||
             die "Failed to pack_source_audioflingerglue-localbuild.sh"

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -312,7 +312,8 @@ if [ "$BUILDGG" = "1" ]; then
             # in case of shallow clone:
             droidmedia_version=999.99999999.99
         fi
-        rpm/dhd/helpers/pack_source_droidmedia-localbuild.sh "$droidmedia_version"
+        rpm/dhd/helpers/pack_source_droidmedia-localbuild.sh "$droidmedia_version" ||
+            die "Failed to pack_source_droidmedia-localbuild.sh"
         mkdir -p hybris/mw/droidmedia-localbuild/rpm
         cp rpm/dhd/helpers/droidmedia-localbuild.spec hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         sed -ie "s/0.0.0/$droidmedia_version/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
@@ -346,7 +347,8 @@ if [ "$BUILDGG" = "1" ]; then
             # in case of shallow clone:
             audioflingerglue_version=999.0.0
         fi
-        rpm/dhd/helpers/pack_source_audioflingerglue-localbuild.sh "$audioflingerglue_version"
+        rpm/dhd/helpers/pack_source_audioflingerglue-localbuild.sh "$audioflingerglue_version" ||
+            die "Failed to pack_source_audioflingerglue-localbuild.sh"
         mkdir -p hybris/mw/audioflingerglue-localbuild/rpm
         cp rpm/dhd/helpers/audioflingerglue-localbuild.spec hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         sed -ie "s/0.0.0/$audioflingerglue_version/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -170,18 +170,22 @@ buildmw() {
     #  -b     Branch to use. If none supplied, use default.
     #  -s     .spec file to use. Can be supplied multiple times.
     #         If empty, will use all .spec files from $PKG/rpm/*.
+    #  -N     Tell mb2 to not fix the version inside a spec file.
 
     local GIT_URL=""
     local GIT_BRANCH=""
     local MW_BUILDSPEC=""
+    # Use global override, if defined
+    local NO_AUTO_VERSION=$NO_AUTO_VERSION
     # This is important for getopt or it will fail on the second invocation!
     local OPTIND
-    while getopts 'u:b:s:' _flag
+    while getopts 'u:b:s:N' _flag
     do
         case "${_flag}" in
             u) GIT_URL="$OPTARG" ;;
             b) GIT_BRANCH="-b $OPTARG" ;;
             s) MW_BUILDSPEC+="$OPTARG " ;;
+            N) NO_AUTO_VERSION=--no-fix-version ;;
             *) echo "buildmw(): Unexpected option $_flag"; exit 1; ;;
         esac
     done
@@ -279,7 +283,8 @@ build() {
     fi
     for SPEC in $SPECS ; do
         minfo "Building $SPEC"
-        mb2 -s $SPEC -t $VENDOR-$DEVICE-$PORT_ARCH build >>$LOG 2>&1|| die "building of package failed"
+        mb2 -s $SPEC -t $VENDOR-$DEVICE-$PORT_ARCH $NO_AUTO_VERSION \
+            build >>$LOG 2>&1|| die "building of package failed"
         # RPMS directory gets emptied when mb2 starts, so let's put packages
         # to the side in case of multiple .spec file builds
         mkdir RPMS.saved &>/dev/null

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -42,7 +42,7 @@ minfo() {
 }
 
 merror() {
-    echo -e "\e[01;31m!! $* \e[00m"
+>&2 echo -e "\e[01;31m!! $* \e[00m"
 }
 
 die() {
@@ -269,6 +269,11 @@ buildmw() {
                 minfo "pulling updates..."
                 git pull >>$LOG 2>&1|| die "pulling of updates failed"
             fi
+        fi
+
+        if [ -z "$NO_AUTO_VERSION" ]; then
+            # Let's check if package has a valid tag for version
+            get_package_version "$PKG" >/dev/null # failure within will exit the script altogether
         fi
 
         if [ "$PKG" = "libhybris" ]; then


### PR DESCRIPTION
@Thaodan implemented ability to instruct mb2 to skip generating version from git tag when such is not available (droidmedia-localbuild) or invalid, this way getting rid of couple of old hacks.

Another feature is to recover tags from shallow clones or if working offline, inform the user about it.