### PR TITLE
dhd: Add editorconfig file to force coding style across repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+insert_final_newline = true
+indent_size = 4
+
+[Makefile,*.mk]
+indent_style = tab
+
+[*.inc]
+# Threat inc files like spec files
+file_type_ext = spec


### PR DESCRIPTION
Editorconfig allows enforcing code style/file settings in support
editors including Github and Gitlab. This avoids fixing PRs on
indentation or use of tabs vs. spaces to indent.

See:
https://editorconfig.org

