### PR TITLE
helpers: Build nfcd from git to avoid breaking libnciplugin git build

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -279,6 +279,7 @@ if [ "$BUILDMW" = "1" ]; then
             buildmw -u "https://github.com/mer-hybris/libgbinder-radio" || die
             buildmw -u "https://github.com/mer-hybris/bluebinder" || die
             buildmw -u "https://github.com/mer-hybris/ofono-ril-binder-plugin" || die
+            buildmw -u "https://git.sailfishos.org/mer-core/nfcd.git" || die
             buildmw -u "https://github.com/mer-hybris/libncicore.git" || die
             buildmw -u "https://github.com/mer-hybris/libnciplugin.git" || die
             buildmw -u "https://github.com/mer-hybris/nfcd-binder-plugin" || die


### PR DESCRIPTION
Fixes the following:
```
$ rpm/dhd/helpers/build_packages.sh --mw
...
* Building of libncicore finished successfully 
* Source code directory doesn't exist, cloning repository 
* pulling updates... 
* No spec file for package building specified, building all I can find. 
* Building rpm/libnciplugin.spec 
Cloning into 'libnciplugin'...
Already up to date.
No provider of 'pkgconfig(nfcd-plugin) >= 1.1.0' found.
Setting version: 1.1.0
hostname: Unknown host
No journal files were found.
error: Failed build dependencies:
	pkgconfig(libncicore) >= 1.1.13 is needed by libnciplugin-1.1.0-0.aarch64
	pkgconfig(nfcd-plugin) >= 1.1.0 is needed by libnciplugin-1.1.0-0.aarch64
Building target platforms: aarch64-meego-linux-gnu
Building for target aarch64-meego-linux-gnu
No journal files were found.
Failed to seek to cursor: Invalid argument
* Check /home/deathmist/Sailfish/src/hybris/mw/libnciplugin.log for full log. 
!! building of package failed
```