### PR TITLE
[audioflingerglue] Fix afglue build on aarch64 target

### DIFF
--- a/helpers/audioflingerglue-localbuild.spec
+++ b/helpers/audioflingerglue-localbuild.spec
@@ -3,7 +3,7 @@
 %define __find_requires     %{nil}
 %global debug_package       %{nil}
 %define __provides_exclude_from ^.*$
-%define device_rpm_architecture_string armv7hl
+%define device_rpm_architecture_string @PORT_ARCH@
 %define _target_cpu %{device_rpm_architecture_string}
 
 

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -379,6 +379,7 @@ if [ "$BUILDGG" = "1" ]; then
         mkdir -p hybris/mw/audioflingerglue-localbuild/rpm
         cp rpm/dhd/helpers/audioflingerglue-localbuild.spec hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         sed -ie "s/0.0.0/$audioflingerglue_version/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
+        sed -ie "s/@PORT_ARCH@/$PORT_ARCH/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         sed -ie "s/@DEVICE@/$HABUILD_DEVICE/" hybris/mw/audioflingerglue-localbuild/rpm/audioflingerglue.spec
         mv hybris/mw/audioflingerglue-"$audioflingerglue_version".tgz hybris/mw/audioflingerglue-localbuild
         buildmw -Nu "audioflingerglue-localbuild" || die

--- a/helpers/pack_source_audioflingerglue-localbuild.sh
+++ b/helpers/pack_source_audioflingerglue-localbuild.sh
@@ -1,9 +1,9 @@
 OUT_DEVICE=${HABUILD_DEVICE:-$DEVICE}
 
-if [ -f ./out/target/product/${OUT_DEVICE}/system/lib/libaudioflingerglue.so ]; then
-    DROIDLIB=lib
-elif [ -f ./out/target/product/${OUT_DEVICE}/system/lib64/libaudioflingerglue.so ]; then
+if [ -f ./out/target/product/${OUT_DEVICE}/system/lib64/libaudioflingerglue.so ]; then
     DROIDLIB=lib64
+elif [ -f ./out/target/product/${OUT_DEVICE}/system/lib/libaudioflingerglue.so ]; then
+    DROIDLIB=lib
 else
     echo "Please build audioflingerglue as per HADK instructions"
     exit 1


### PR DESCRIPTION
This fix audioflingerglue build on aarch64 target, without this patch afglue build log:
```
Processing files: audioflingerglue-0.0.13-1.armv7hl
Provides: audioflingerglue = 0.0.13-1 audioflingerglue(aarch-64) = 0.0.13-1
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Processing files: audioflingerglue-devel-0.0.13-1.noarch
Provides: audioflingerglue-devel = 0.0.13-1
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/bird/work/hadk_14.1/hybris/mw/audioflingerglue-localbuild/installroot
Wrote: /home/bird/work/hadk_14.1/hybris/mw/audioflingerglue-localbuild/RPMS/audioflingerglue-0.0.13-1.armv7hl.rpm
Wrote: /home/bird/work/hadk_14.1/hybris/mw/audioflingerglue-localbuild/RPMS/audioflingerglue-devel-0.0.13-1.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.bOYRG3
+ umask 022
+ cd /home/bird/work/hadk_14.1/hybris/mw/audioflingerglue-localbuild
+ /bin/rm -rf /home/bird/work/hadk_14.1/hybris/mw/audioflingerglue-localbuild/installroot
+ exit 0
07:59:35: posix_spawn avoided (fd close requested) 
07:59:35: posix_spawn avoided (fd close requested) 
07:59:35: posix_spawn avoided (fd close requested) 
07:59:35: posix_spawn avoided (fd close requested) 
Directory walk started
Directory walk done - 80 packages
Temporary output repo path: /home/bird/work/hadk_14.1/droid-local-repo/vince/.repodata/
Preparing sqlite DBs
Pool started (with 5 workers)
Pool finished
Got http_proxy from environment, will not talk to connman
DBus unavailable, falling back to libssu
Loading repository data...
Retrieving repository 'adaptation-community-common' data...
Retrieving repository 'adaptation-community-common' metadata [.done]
Reading installed packages...
Forcing installation of 'audioflingerglue-devel-0.0.13-1.noarch' from repository 'Plain RPM files cache'.
'_tmpRPMcache_:audioflingerglue=0:0.0.13-1' not found in package names. Trying capabilities.
No provider of '_tmpRPMcache_:audioflingerglue=0:0.0.13-1' found.
```