### PR TITLE
dhd: Move droid headers to /usr/include

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -526,7 +526,7 @@ mkdir -p $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/lib-dev-alog/
 mkdir -p $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/lib64-dev-alog/
 %endif
 mkdir -p $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system
-mkdir -p $RPM_BUILD_ROOT%{dhdlibdir}/droid-devel/
+mkdir -p $RPM_BUILD_ROOT%{_includedir}/droid-devel/
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 mkdir -p $RPM_BUILD_ROOT/lib/udev/rules.d
 mkdir -p $RPM_BUILD_ROOT/etc/udev/rules.d
@@ -615,8 +615,8 @@ fi
 
 # Remove kernel modules if installed under /system/lib/modules
 rm -rf $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib/modules
-cp -a %{android_root}/out/target/product/%{device}/obj/include $RPM_BUILD_ROOT%{dhdlibdir}/droid-devel/
-rm -rf $RPM_BUILD_ROOT%{dhdlibdir}/droid-devel/lib/*.so.toc
+cp -a %{android_root}/out/target/product/%{device}/obj/include $RPM_BUILD_ROOT%{_includedir}/droid-devel/
+rm -rf $RPM_BUILD_ROOT%{_includedir}/droid-devel/lib/*.so.toc
 
 # Omit audioflingerglue bits, they get packaged via audioflingerglue-localbuild
 rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/{lib,lib64}/libaudioflingerglue.so
@@ -627,20 +627,20 @@ rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/{lib,lib64}/libminisf.so
 rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/bin/minimediaservice
 rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/bin/minisfservice
 
-hdrs=$RPM_BUILD_ROOT%{dhdlibdir}/droid-devel/droid-headers
+hdrs=$RPM_BUILD_ROOT%{_includedir}/droid-devel/droid-headers
 mkdir -p $hdrs
 
 # Run extract-headers.sh
 %if 0%{!?provides_own_headers:1}
 echo "Extracting headers for hybris"
 # This is copied from libhybris and should be kept in-sync:
-%{dhd_path}/helpers/extract-headers.sh -p %{dhdlibdir}/droid-devel/droid-headers . $hdrs/ > /dev/null
+%{dhd_path}/helpers/extract-headers.sh -p %{_includedir}/droid-devel/droid-headers . $hdrs/ > /dev/null
 if [ -d "%{android_root}/rpm/header_patches" ]; then
     %{dhd_path}/helpers/patch-headers.sh "$hdrs" "%{android_root}/rpm/header_patches"/*.patch
 fi
 %else
 pushd %{android_root}/rpm/droid-headers 1>/dev/null
-make install DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_prefix} INCLUDEDIR=%{dhdlibdir}/droid-devel/droid-headers
+make install DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_prefix} INCLUDEDIR=%{_includedir}/droid-devel/droid-headers
 popd 1>/dev/null
 %endif
 
@@ -764,7 +764,7 @@ done
 #mv $RPM_BUILD_ROOT/charger $RPM_BUILD_ROOT/sbin/droid-hal-charger
 
 # for use in the -devel package
-cp tmp/hw-release %{buildroot}/%{dhdlibdir}/droid-devel/hw-release.vars
+cp tmp/hw-release %{buildroot}/%{_includedir}/droid-devel/hw-release.vars
 
 # Store the groups that users need to be in to access various subsystems this HA provides
 # These are the default android ones:
@@ -1001,7 +1001,7 @@ done
 
 %files devel
 %defattr(644,root,root,-)
-%{dhdlibdir}/droid-devel/
+%{_includedir}/droid-devel/
 %if 0%{?_obs_build_project:1}
 # this hack fixes OBS i586 worker failure
 %{_prefix}/lib*/pkgconfig/*pc

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -205,7 +205,12 @@ if [ "$BUILDMW" = "1" ]; then
         sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -msdk-install zypper -n install $ALLOW_UNSIGNED_RPM droid-hal-$HABUILD_DEVICE-devel
     fi
 
-    android_version_major=$(sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R cat /usr/$_LIB/droid-devel/droid-headers/android-version.h 2>/dev/null |grep "#define.*ANDROID_VERSION_MAJOR" |sed -e "s/#define.*ANDROID_VERSION_MAJOR//g")
+    if [ -f "/usr/include/droid-devel/droid-headers/android-version.h" ]; then
+        android_version_header=/usr/include/droid-devel/droid-headers/android-version.h
+    else
+        android_version_header=/usr/$_LIB/droid-devel/droid-headers/android-version.h
+    fi
+    android_version_major=$(sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R cat $android_version_header 2>/dev/null |grep "#define.*ANDROID_VERSION_MAJOR" |sed -e "s/#define.*ANDROID_VERSION_MAJOR//g")
 
     pushd $ANDROID_ROOT/hybris/mw > /dev/null
 


### PR DESCRIPTION
[dhd] Move droid headers to /usr/include