### PR TITLE
droidmedia-localbuild: Don't package droidmedia-devel by default

### DIFF
--- a/helpers/droidmedia-localbuild.spec
+++ b/helpers/droidmedia-localbuild.spec
@@ -6,6 +6,8 @@
 %define device_rpm_architecture_string @PORT_ARCH@
 %define _target_cpu %{device_rpm_architecture_string}
 
+%bcond_with droidmedia_devel
+
 Name:          droidmedia
 Summary:       Android media wrapper library
 Version:       0.0.0
@@ -22,6 +24,7 @@ AutoReqProv:   no
 %description
 %{summary}
 
+%if %{with droidmedia_devel}
 %package       devel
 Summary:       droidmedia development headers
 Group:         System/Libraries
@@ -30,6 +33,7 @@ BuildArch:     noarch
 
 %description   devel
 %{summary}
+%endif
 
 %prep
 
@@ -62,7 +66,6 @@ fi
 
 mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
-mkdir -p $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/droidmedia/
 cp out/target/product/@DEVICE@/system/$DROIDLIB/libdroidmedia.so \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
@@ -76,8 +79,12 @@ cp out/target/product/@DEVICE@/system/bin/minimediaservice \
 cp out/target/product/@DEVICE@/system/bin/minisfservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
+%if %{with droidmedia_devel}
+mkdir -p $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
 cp external/droidmedia/*.h $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
 cp external/droidmedia/hybris.c $RPM_BUILD_ROOT/%{_datadir}/droidmedia/
+%endif
+
 popd
 
 LIBDMSOLOC=file.list
@@ -89,8 +96,9 @@ echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libminisf.so >> ${LIBDMSOLOC}
 %{_libexecdir}/droid-hybris/system/bin/minimediaservice
 %{_libexecdir}/droid-hybris/system/bin/minisfservice
 
+%if %{with droidmedia_devel}
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/droidmedia/*.h
 %{_datadir}/droidmedia/hybris.c
-
+%endif


### PR DESCRIPTION
Since droidmedia-devel comes from adaption-common

[droidmedia-localbuild] Don't package droidmedia-devel by default. JB#55878