### PR TITLE
Build droidmedia-devel directly from source repo

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -328,6 +328,7 @@ if [ "$BUILDGG" = "1" ]; then
         sed -ie "s/@DEVICE@/$HABUILD_DEVICE/" hybris/mw/droidmedia-localbuild/rpm/droidmedia.spec
         mv hybris/mw/droidmedia-"$droidmedia_version".tgz hybris/mw/droidmedia-localbuild
         buildmw -Nu "droidmedia-localbuild" || die
+        buildmw -u "droidmedia" -s "rpm/droidmedia-devel.spec"
         if grep -qs "^Requires: gstreamer1.0-droid" "$pattern_lookup"; then
             buildmw -u "https://github.com/sailfishos/gst-droid.git" || die
         else

--- a/helpers/droidmedia-localbuild.spec
+++ b/helpers/droidmedia-localbuild.spec
@@ -22,15 +22,6 @@ AutoReqProv:   no
 %description
 %{summary}
 
-%package       devel
-Summary:       droidmedia development headers
-Group:         System/Libraries
-Requires:      droidmedia = %{version}-%{release}
-BuildArch:     noarch
-
-%description   devel
-%{summary}
-
 %prep
 
 %if %{?device_rpm_architecture_string:0}%{!?device_rpm_architecture_string:1}
@@ -76,8 +67,6 @@ cp out/target/product/@DEVICE@/system/bin/minimediaservice \
 cp out/target/product/@DEVICE@/system/bin/minisfservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
-cp external/droidmedia/*.h $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
-cp external/droidmedia/hybris.c $RPM_BUILD_ROOT/%{_datadir}/droidmedia/
 popd
 
 LIBDMSOLOC=file.list
@@ -88,9 +77,4 @@ echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libminisf.so >> ${LIBDMSOLOC}
 %defattr(-,root,root,-)
 %{_libexecdir}/droid-hybris/system/bin/minimediaservice
 %{_libexecdir}/droid-hybris/system/bin/minisfservice
-
-%files devel
-%defattr(-,root,root,-)
-%{_includedir}/droidmedia/*.h
-%{_datadir}/droidmedia/hybris.c
 

--- a/helpers/pack_source_droidmedia-localbuild.sh
+++ b/helpers/pack_source_droidmedia-localbuild.sh
@@ -18,10 +18,7 @@ mkdir $fold
 
 mkdir -p $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}
 mkdir -p $fold/out/target/product/${OUT_DEVICE}/system/bin
-mkdir -p $fold/external/droidmedia
 
-cp ./external/droidmedia/*.h $fold/external/droidmedia/
-cp ./external/droidmedia/hybris.c $fold/external/droidmedia/
 cp ./out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/libdroidmedia.so $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/
 cp ./out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/libminisf.so $fold/out/target/product/${OUT_DEVICE}/system/${DROIDLIB}/
 cp ./out/target/product/${OUT_DEVICE}/system/bin/minimediaservice $fold/out/target/product/${OUT_DEVICE}/system/bin/


### PR DESCRIPTION
Ever since [this commit](https://github.com/sailfishos/droidmedia/commit/7360103b7a78f5d92cde147680fbe6f8c68b8ea4) to droidmedia in July, local builds have been broken. This is due to gst-droid requiring a pkgconfig file (droidmedia.pc) which isn't built here as part of droidmedia-localbuild.

This patch fixes the `./rpm/dhd/helpers/build_packages.sh --gg` step. It looks like this repo might be in the middle of a refactor that also fixes the issue, but in the meantime if you're trying to just build something locally here's how to sort it out.