### PR TITLE
helpers: fix local build of pulseaudio-modules-droid-hidl

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -278,6 +278,7 @@ if [ "$BUILDMW" = "1" ]; then
 
         buildmw -u "https://github.com/mer-hybris/pulseaudio-modules-droid.git" \
                 -s rpm/pulseaudio-modules-droid.spec || die
+        buildmw -u "https://github.com/mer-hybris/audiosystem-passthrough.git" || die
         buildmw -u "https://github.com/mer-hybris/pulseaudio-modules-droid-hidl.git" || die
         buildmw -u "https://github.com/mer-hybris/mce-plugin-libhybris" || die
         buildmw -u "https://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin" || die


### PR DESCRIPTION
Remove this line when audiosystem-passthrough-devel gets added to the public hw:common.