### PR TITLE
Fix SDK snapshot update

### DIFF
--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -186,6 +186,8 @@ if [ "$BUILDCONFIGS" = "1" ]; then
     buildconfigs
     if grep -qsE "^(-|Requires:) droid-config-$DEVICE-bluez5" hybris/droid-configs/patterns/*.inc; then
         sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -m sdk-install -R zypper -n install droid-config-$DEVICE-bluez5
+        # If using the latest SDK with snapshots, remove it to avoid /etc/bluetooth as symlink failure later on
+        sdk-assistant remove --non-interactive --snapshots-of $VENDOR-$DEVICE-$PORT_ARCH >/dev/null || true
     fi
 fi
 

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -351,7 +351,7 @@ deploy() {
     if [ "$BUILDOFFLINE" = "1" ]; then
         sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -m sdk-install zypper ref local-$DEVICE-hal || die "can't refresh local hal repo"
     else
-        sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -m sdk-install zypper ref || die "can't refresh repositories"
+        sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -m sdk-install zypper ref || die "can't refresh repositories"
     fi
     DO_NOT_INSTALL=$2
     if [ "$PKG" = "libhybris" ]; then


### PR DESCRIPTION
Fixes the error after installing bluez5 packages:
`cp: cannot overwrite directory '/srv/mer/targets/$VENDOR-$DEVICE-$PORT_ARCH.default/etc/bluetooth' with non-directory`
