### PR TITLE
helpers: work around busybox-cpio replacement symlink clash

### DIFF
--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -305,6 +305,8 @@ buildmw() {
             if [ ! $ret -eq 104 ]; then
                 minfo "Applying cpio fix..."
                 sb2 -t $VENDOR-$DEVICE-$PORT_ARCH -R -m sdk-install zypper --non-interactive install --force-resolution cpio>>$LOG 2>&1|| die "can't install cpio"
+                # If using the latest SDK with snapshots, remove it to avoid busybox symlinks failure later on
+                sdk-assistant remove --non-interactive --snapshots-of $VENDOR-$DEVICE-$PORT_ARCH >/dev/null || true
             fi
         fi
 


### PR DESCRIPTION
This happens when the localbuild of droid-hal-img-boot applies
the fix by replacing busybox's cpio with the GNU/cpio.

Can be removed for the next update after 4.3.0.x