### PR TITLE
dhd: Immediately fail Android builds on OBS if a command fails

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -398,9 +398,16 @@ else
     echo "Kernel Makefile not found, skipping EXTRAVERSION appending"
 fi
 
-# Hadk style build of android on OBS 
+# Hadk style build of android on OBS
+
+# We can check if we have new or old ubu-chroot by checking if it has the -V  option
+# added with this version.
+if ubu-chroot -V ; then
+   sh="sh -c"
+fi
+
 echo Running droid build in HABUILD_SDK
-ubu-chroot -r /srv/mer/sdks/ubu "cd %android_root; %{?pre_actions}%{!?pre_actions:true}; source build/envsetup.sh; lunch %{?lunch_device}%{!?lunch_device:%{device}}%{?device_variant}; rm -f .repo/local_manifests/roomservice.xml; make %{?_smp_mflags} %{?hadk_make_target}%{!?hadk_make_target:hybris-hal}"
+ubu-chroot -r /srv/mer/sdks/ubu ${sh} "set -o errexit; cd %android_root; %{?pre_actions}%{!?pre_actions:true}; source build/envsetup.sh; lunch %{?lunch_device}%{!?lunch_device:%{device}}%{?device_variant}; rm -f .repo/local_manifests/roomservice.xml; make %{?_smp_mflags} %{?hadk_make_target}%{!?hadk_make_target:hybris-hal}"
 %endif
 
 # Make a tmp location for built installables


### PR DESCRIPTION
Run the Android build commands with set -e/errexit so that in case on
them fails the shell directly exits instead of silently continuing.