### PR TITLE
dhd: Do not install /sbin/mkdosfs binary.

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -776,7 +776,8 @@ _remove_cruft   "/fstab.*"          \
                 "/charger"          \
                 "/res"              \
                 "/data"             \
-                "/odm/*"
+                "/odm/*"            \
+                "/sbin/mkdosfs"
 if [ $android_version_major -lt "7" ]; then
     _remove_cruft "/property_contexts"
 fi


### PR DESCRIPTION
[dhd] Do not install /sbin/mkdosfs binary. JB#58522

Some Android build compile /sbin/mkdosfs binary which is
conflicting to busybox-symlinks-dosfstools in image building phase.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>