### PR TITLE
Fix checking kernel version when dtbo.img has been built

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -848,7 +848,7 @@ fi
 
 # Kernel and module installation; to
 # /boot and modules to /lib as normal
-kernel_release=$(cat out/target/product/%{device}/*/*/include/config/kernel.release)
+kernel_release=$(sort -u out/target/product/%{device}/*/*/include/config/kernel.release)
 cp out/target/product/%{device}/kernel $RPM_BUILD_ROOT/boot/kernel-$kernel_release
 cp out/target/product/%{device}/obj/ROOT/hybris-boot_intermediates/boot-initramfs.gz $RPM_BUILD_ROOT/boot/
 

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -198,9 +198,9 @@ if [ "$BUILDMW" = "1" ]; then
     fi
 
     if [ "$FAMILY" == "" ]; then
-        sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper -n $PLUS_LOCAL_REPO install $ALLOW_UNSIGNED_RPM droid-hal-$DEVICE-devel
+        sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper -n $PLUS_LOCAL_REPO install --allow-unsigned-rpm droid-hal-$DEVICE-devel
     else
-        sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper -n $PLUS_LOCAL_REPO install $ALLOW_UNSIGNED_RPM droid-hal-$HABUILD_DEVICE-devel
+        sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper -n $PLUS_LOCAL_REPO install --allow-unsigned-rpm droid-hal-$HABUILD_DEVICE-devel
     fi
 
     if [ "$(sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH ls -A /usr/include/droid-devel/droid-headers/android-version.h 2> /dev/null)" ]; then

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -335,7 +335,7 @@ build() {
             -t $VENDOR-$DEVICE-$PORT_ARCH \
             $PACKAGE_TIMELINE $NO_AUTO_VERSION \
             --output-dir "$LOCAL_REPO" \
-            build >>$LOG 2>&1|| die "building of package failed"
+            build --no-check >>$LOG 2>&1|| die "building of package failed"
     done
     minfo "Building of $PKG finished successfully"
 }


### PR DESCRIPTION
Disable checks from builds. Add missing --allow-unsigned-rpm to some install commands.