### PR TITLE
Android 12 and 13 support and various fixes

### DIFF
--- a/droid-hal-device.inc
+++ b/droid-hal-device.inc
@@ -459,7 +459,14 @@ fi
 # files have changed in android >=8 so we need to supply different ones to the
 # makefile. we also need the cstring workaround thus handling both issues here
 # at once
-if [ $android_version_major -ge "8" ]; then
+if [ $android_version_major -ge "13" ]; then
+    # sparse_read.cpp doesn't include cstring and therefore fails for us
+    # workaround:
+    echo "#include <cstring>" > $ANDROID_ROOT/system/core/libsparse/sparse_read_fix.cpp
+    echo "#include \"sparse_read.cpp\"" >> $ANDROID_ROOT/system/core/libsparse/sparse_read_fix.cpp
+    IMG2SIMG_SOURCES="backed_block.c output_file.c sparse.c sparse_crc32.c sparse_err.c sparse_read_fix.cpp img2simg.c ../../libbase/mapped_file.cpp ../../libbase/stringprintf.cpp"
+    SIMG2IMG_SOURCES="backed_block.c output_file.c sparse.c sparse_crc32.c sparse_err.c sparse_read_fix.cpp simg2img.c ../../libbase/mapped_file.cpp ../../libbase/stringprintf.cpp"
+elif [ $android_version_major -ge "8" ]; then
     # sparse_read.cpp doesn't include cstring and therefore fails for us
     # workaround:
     echo "#include <cstring>" > $ANDROID_ROOT/system/core/libsparse/sparse_read_fix.cpp
@@ -560,6 +567,14 @@ fi
 install -m 755 \
     -D %{android_root}/system/$mkbootimg_dir/mkbootimg/${_mkbootimg:-mkbootimg} \
     %{buildroot}/%{_bindir}/mkbootimg
+if [ $android_version_major -ge "13" ]; then
+install -m 755 \
+    -D %{android_root}/system/$mkbootimg_dir/mkbootimg/gki/generate_gki_certificate.py \
+    %{buildroot}/%{_bindir}/gki/generate_gki_certificate.py
+echo "%{_bindir}/gki/generate_gki_certificate.py" > tools.files
+else
+echo "" > tools.files
+fi
 
 install -m 755 -D %{android_root}/system/core/libsparse/simg2img %{buildroot}/%{_bindir}/
 install -m 755 -D %{android_root}/system/core/libsparse/img2simg %{buildroot}/%{_bindir}/
@@ -612,6 +627,10 @@ else
 echo "" > tmp/droid-hal.files
 fi
 
+if [ $android_version_major -lt "13" ]; then
+echo "/default.prop" > tmp/droid-hal.files
+fi
+
 cp -a %{android_root}/out/target/product/%{device}/system/{bin,lib} $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/.
 %if 0%{?droid_target_aarch64:1}
 cp -a %{android_root}/out/target/product/%{device}/system/lib64 $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/.
@@ -635,12 +654,15 @@ if [ $android_version_major -ge "10" ]; then
         art_path=%{android_root}/out/target/product/%{device}
         apex_path=apex/com.android.runtime
     fi
+
+    rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib/lib{dl,dl_android,c,m}.so
     cp -a \
-        $art_path/$apex_path/lib/bionic/lib{dl,c,m}.so \
+        $art_path/$apex_path/lib/bionic/lib{dl,dl_android,c,m}.so \
         $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib
 %if 0%{?droid_target_aarch64:1}
+    rm -f $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib64/lib{dl,dl_android,c,m}.so
     cp -a \
-        $art_path/$apex_path/lib64/bionic/lib{dl,c,m}.so \
+        $art_path/$apex_path/lib64/bionic/lib{dl,dl_android,c,m}.so \
         $RPM_BUILD_ROOT%{_libexecdir}/droid-hybris/system/lib64
 %endif
 fi
@@ -694,6 +716,16 @@ if (grep -q '^TARGET_USES_QCOM_BSP := true' %{android_root}/device/%{vendor}/*/B
 /* Added by automatic QCOM_BSP detection */
 #define QCOM_BSP 1
 #define QTI_BSP 1
+EOF
+fi
+if [ $android_version_major -ge "13" ]; then
+    cat <<EOF >> $hdrs/android-config.h.new
+/* For Android 13+ */
+#define __BIONIC_VERSIONER
+#define _Nonnull
+#define _Nullable
+
+#include <android/versioning.h>
 EOF
 fi
 sed "1,$token_line d" $hdrs/android-config.h >> $hdrs/android-config.h.new
@@ -859,6 +891,10 @@ if cp out/target/product/%{device}/dt.img $RPM_BUILD_ROOT/boot/ &> /dev/null; th
     echo /boot/dt.img >> kernel.files
 fi
 
+if cp out/target/product/%{device}/dtb.img $RPM_BUILD_ROOT/boot/ &> /dev/null; then
+    echo /boot/dtb.img >> kernel.files
+fi
+
 touch dtbo.files
 
 if cp out/target/product/%{device}/%{dtbo_binary} $RPM_BUILD_ROOT/boot/dtbo.img &> /dev/null; then
@@ -1022,7 +1058,6 @@ done
 /lib/udev/rules.d/*
 # Droid config droppings
 /*.rc
-/default.prop
 # Disabling v4l.rules
 %{_sysconfdir}/udev/rules.d/60-persistent-v4l.rules
 
@@ -1042,7 +1077,7 @@ done
 %{dhdlibdir}/pkgconfig/*pc
 %endif
 
-%files tools
+%files tools -f tools.files
 %defattr(-,root,root,-)
 %{_bindir}/mkbootimg
 %{_bindir}/img2simg

--- a/helpers/audioflingerglue-localbuild.spec
+++ b/helpers/audioflingerglue-localbuild.spec
@@ -11,7 +11,6 @@ Name:          audioflingerglue
 Summary:       Android AudioFlinger glue library
 Version:       0.0.0
 Release:       1
-Group:         System/Libraries
 License:       ASL 2.0
 BuildRequires: tar
 Source0:       %{name}-%{version}.tgz
@@ -22,7 +21,6 @@ AutoReqProv:   no
 
 %package       devel
 Summary:       audioflingerglue development headers
-Group:         System/Libraries
 Requires:      audioflingerglue = %{version}-%{release}
 BuildArch:     noarch
 

--- a/helpers/build_packages.sh
+++ b/helpers/build_packages.sh
@@ -289,15 +289,6 @@ if [ "$BUILDMW" = "1" ]; then
             buildmw -u "https://github.com/mer-hybris/geoclue-providers-hybris" \
                     -s rpm/geoclue-providers-hybris.spec || die
         fi
-        # build kf5bluezqt-bluez4 if not yet provided by Sailfish OS itself
-        sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper se kf5bluezqt-bluez4 > /dev/null
-        ret=$?
-        if [ $ret -eq 104 ]; then
-            buildmw -u "https://github.com/sailfishos/kf5bluezqt.git" \
-                    -s rpm/kf5bluezqt-bluez4.spec || die
-            # pull device's bluez4 configs correctly
-            sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper remove bluez-configs-mer
-        fi
     fi
 fi
 

--- a/helpers/droidmedia-localbuild.spec
+++ b/helpers/droidmedia-localbuild.spec
@@ -77,7 +77,7 @@ echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libdroidmedia.so >> ${LIBDMSOL
 echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libminisf.so >> ${LIBDMSOLOC}
 
 if [ -d $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/etc/init ]; then
-echo %{_libexecdir}/droid-hybris/system/etc/init/*.rc >> ${LIBDMSOLOC}
+find $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/etc/init -type f -name '*.rc' -exec sh -c 'echo %{_libexecdir}/droid-hybris/system/etc/init/$(basename {})' >> ${LIBDMSOLOC} \;
 fi
 
 %files -f file.list

--- a/helpers/droidmedia-localbuild.spec
+++ b/helpers/droidmedia-localbuild.spec
@@ -10,7 +10,6 @@ Name:          droidmedia
 Summary:       Android media wrapper library
 Version:       0.0.0
 Release:       1
-Group:         System/Libraries
 License:       ASL 2.0
 BuildRequires: tar
 #BuildRequires: ubu-trusty

--- a/helpers/extract-headers.sh
+++ b/helpers/extract-headers.sh
@@ -209,8 +209,17 @@ extract_headers_to hardware_legacy \
 extract_headers_to cutils \
     system/core/include/cutils
 
-extract_headers_to log \
-    system/core/include/log
+!(check_header_exists system/logging/liblog/include/log/log.h) && \
+    extract_headers_to log \
+        system/core/include/log
+
+check_header_exists system/logging/liblog/include/log/log.h && \
+    extract_headers_to log \
+        system/logging/liblog/include/log
+
+check_header_exists system/logging/liblog/include/android/log.h && \
+    extract_headers_to android \
+        system/logging/liblog/include/android
 
 extract_headers_to system \
     system/core/include/system
@@ -221,6 +230,10 @@ check_header_exists system/media/audio/include/system/audio.h && \
 
 extract_headers_to android \
     system/core/include/android
+
+check_header_exists bionic/libc/include/android/versioning.h && \
+    extract_headers_to android \
+        bionic/libc/include/android/versioning.h
 
 check_header_exists bionic/libc/kernel/common/linux/sync.h && \
     extract_headers_to linux \

--- a/helpers/img2simg.mk
+++ b/helpers/img2simg.mk
@@ -2,10 +2,10 @@
 
 IMG2SIMG_SOURCES?= nosourcessupplied
 
-CXXFLAGS+= -std=gnu++11
+CXXFLAGS+= -std=gnu++14
 
 CPPFLAGS+= -Iinclude
-CPPFLAGS+= -I../base/include
+CPPFLAGS+= -I../base/include -I../../libbase/include
 
 TMP_OBJS=$(IMG2SIMG_SOURCES:.cpp=.o)
 OBJS=$(TMP_OBJS:.c=.o)

--- a/helpers/makefile
+++ b/helpers/makefile
@@ -13,7 +13,7 @@ IMG2SIMG_MK ?= $(shell pwd)/img2simg.mk
 SIMG2IMG_MK ?= $(shell pwd)/simg2img.mk
 
 # Include directories
-CFLAGS += -I$(ANDROID_ROOT)/system/core/include/ -I$(ANDROID_ROOT)/
+CFLAGS += -I$(ANDROID_ROOT)/system/core/include/ -I$(ANDROID_ROOT)/system/core/libcutils/include/ -I$(ANDROID_ROOT)/ -I$(ANDROID_ROOT)/system/libbase/include/
 
 all: $(TOOLS) $(MKBOOTIMG) image_tools
 

--- a/helpers/simg2img.mk
+++ b/helpers/simg2img.mk
@@ -2,10 +2,10 @@
 
 SIMG2IMG_SOURCES?= nosourcessupplied
 
-CXXFLAGS+= -std=gnu++11
+CXXFLAGS+= -std=gnu++14
 
 CPPFLAGS+= -Iinclude
-CPPFLAGS+= -I../base/include
+CPPFLAGS+= -I../base/include -I../../libbase/include
 
 TMP_OBJS=$(SIMG2IMG_SOURCES:.cpp=.o)
 OBJS=$(TMP_OBJS:.c=.o)

--- a/helpers/util.sh
+++ b/helpers/util.sh
@@ -233,6 +233,13 @@ buildmw() {
             minfo "No git url specified, assuming $GIT_URL"
         fi
 
+        sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper se -i ccache > /dev/null
+        ret=$?
+        if [ $ret -eq 104 ]; then
+            minfo "Installing ccache..."
+            sdk-assistant maintain $VENDOR-$DEVICE-$PORT_ARCH zypper -n install ccache>>$LOG 2>&1|| die "can't install ccache"
+        fi
+
         if [ -d "$ANDROID_ROOT/external/$PKG" ]; then
             pushd "$ANDROID_ROOT/external" > /dev/null || die
 


### PR DESCRIPTION
Add Android 12 and 13 support.
Install ccache to target.
Do not build kf5bluezqt-bluez4.
Remove useless Group tags from audioflinger and droidmedia spec files.
Fix packaging init files in droidmedia-localbuild spec.